### PR TITLE
Fix 4 minor notifier related issues/bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.0.0
+VERSION = 1.0.1
 IMAGE = cyclops:$(VERSION)
 
 MANAGER_BIN = cyclops

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.0.1
+VERSION = 1.0.0
 IMAGE = cyclops:$(VERSION)
 
 MANAGER_BIN = cyclops

--- a/deploy/crds/atlassian.com_cyclenoderequests_crd.yaml
+++ b/deploy/crds/atlassian.com_cyclenoderequests_crd.yaml
@@ -259,6 +259,10 @@ spec:
                   - providerId
                   type: object
                 type: array
+              numNodesCycled:
+                description: NumNodesCycled counts how many nodes have finished being
+                  cycled
+                type: integer
               phase:
                 description: Phase stores the current phase of the CycleNodeRequest
                 type: string

--- a/pkg/apis/atlassian/v1/cyclenoderequest_types.go
+++ b/pkg/apis/atlassian/v1/cyclenoderequest_types.go
@@ -65,6 +65,9 @@ type CycleNodeRequestStatus struct {
 	// SelectedNodes stores all selected nodes so that new nodes which are selected are only posted in a notification once
 	SelectedNodes map[string]bool `json:"selectedNodes,omitempty"`
 
+	// NumNodesCycled counts how many nodes have finished being cycled
+	NumNodesCycled int `json:"numNodesCycled,omitempty"`
+
 	// NodesAvailable stores the nodes still available to pick up for cycling from the list of nodes to terminate
 	NodesAvailable []CycleNodeRequestNode `json:"nodesAvailable,omitempty"`
 }


### PR DESCRIPTION
Fixing 4 minor issues/bugs

- Switched from using `cnr.Spec.NodeNames` to `cnr.Status.NodesToTerminate` in the progress field to account for `NodeNames` being empty when cycling an entire nodegroup. The progress field is left empty until the `NodesToTerminate` can be counted.
- Improved the progress field to count nodes that have been successfully cycled instead of counting the nodes that have been selected for cycling. A new field in the cnr is added: `cnr.Stats.NumNodesCycled`.
- Fixed the issue where `cnr.Spec.NodeGroupName` is empty because `cnr.Spec.NodeGroupList` is used instead. The nodegroup field now join all nodegroups listed across both cnr fields. As a result of this, the ordering of the field in the notification message has been changed to place the nodegroup field at the bottom.
- Fixed bug where `cnr.Status.NodesAvailable` isn't populated when an entire Nodegroup is cycled by leaving `cnr.Spec.NodeNames` empty. This oversight would allow cyclops to flip-flop between phases rapidly and cause it to hit slack API limits.