### PR TITLE
Fixed flip-flopping when pod cannot be drained + added CNR name validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.1.0
+VERSION = 1.1.1
 IMAGE = cyclops:$(VERSION)
 
 MANAGER_BIN = cyclops

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.1.1
+VERSION = 1.1.0
 IMAGE = cyclops:$(VERSION)
 
 MANAGER_BIN = cyclops

--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -40,6 +40,12 @@ func (t *CycleNodeRequestTransitioner) transitionUndefined() (reconcile.Result, 
 		return t.transitionToHealing(fmt.Errorf("selector cannot be empty"))
 	}
 
+	// Protect against failure case where cyclops checks for leftover CycleNodeStatus objects using the CycleNodeRequest name in the label selector
+	// Label values must be no more than 63 characters long
+	if len(t.cycleNodeRequest.Name) > 63 {
+		return t.transitionToFailed(fmt.Errorf("cycleNodeRequest name must be no more than 63 characters"))
+	}
+
 	// Transition the object to pending
 	return t.transitionObject(v1.CycleNodeRequestPending)
 }

--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -26,18 +26,18 @@ var (
 func (t *CycleNodeRequestTransitioner) transitionUndefined() (reconcile.Result, error) {
 	t.rm.LogEvent(t.cycleNodeRequest, "Initialising", "Initialising cycleNodeRequest")
 
+	if t.rm.Notifier != nil {
+		if err := t.rm.Notifier.CyclingStarted(t.cycleNodeRequest); err != nil {
+			t.rm.Logger.Error(err, "Unable to post message to messaging provider", "phase", t.cycleNodeRequest.Status.Phase)
+		}
+	}
+
 	// Check fields on the cycleNodeRequest for validity. We rely on the CRD validation rules
 	// to do most of the work here for us.
 
 	// Check to ensure a label selector has been provided
 	if t.cycleNodeRequest.Spec.Selector.Size() == 0 {
 		return t.transitionToHealing(fmt.Errorf("selector cannot be empty"))
-	}
-
-	if t.rm.Notifier != nil {
-		if err := t.rm.Notifier.CyclingStarted(t.cycleNodeRequest); err != nil {
-			t.rm.Logger.Error(err, "Unable to post message to messaging provider", "phase", t.cycleNodeRequest.Status.Phase)
-		}
 	}
 
 	// Transition the object to pending

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -141,6 +141,8 @@ func (t *CycleNodeRequestTransitioner) reapChildren() (v1.CycleNodeRequestPhase,
 	}
 
 	// If we've finished most of our children, go back to Initialised to add some more nodes
+	// It is assumed that nodes selected for cycling will take roughly the same time to finish
+	// Bringing up multiple nodes together will speed up the whole process as well as spread out pods properly across the new nodes
 	// If the next phase should be failed, skip this since transitioning back to initialised would be flip-flopping behaviour
 	if nextPhase != v1.CycleNodeRequestFailed && t.cycleNodeRequest.Status.ActiveChildren <= t.cycleNodeRequest.Spec.CycleSettings.Concurrency/2 {
 		t.rm.Logger.Info("Transition back to Initialised to grab more child nodes", "ActiveChildren", t.cycleNodeRequest.Status.ActiveChildren, "Concurrency", t.cycleNodeRequest.Spec.CycleSettings.Concurrency)

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -136,7 +136,8 @@ func (t *CycleNodeRequestTransitioner) reapChildren() (v1.CycleNodeRequestPhase,
 	}
 
 	// If we've finished most of our children, go back to Initialised to add some more nodes
-	if t.cycleNodeRequest.Status.ActiveChildren <= t.cycleNodeRequest.Spec.CycleSettings.Concurrency/2 {
+	// If the next phase should be failed, skip this since transitioning back to initialised would be flip-flopping behaviour
+	if nextPhase != v1.CycleNodeRequestFailed && t.cycleNodeRequest.Status.ActiveChildren <= t.cycleNodeRequest.Spec.CycleSettings.Concurrency/2 {
 		t.rm.Logger.Info("Transition back to Initialised to grab more child nodes", "ActiveChildren", t.cycleNodeRequest.Status.ActiveChildren, "Concurrency", t.cycleNodeRequest.Spec.CycleSettings.Concurrency)
 		nextPhase = v1.CycleNodeRequestInitialised
 	}

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -23,6 +23,11 @@ func (t *CycleNodeRequestTransitioner) transitionToHealing(err error) (reconcile
 
 // transitionToFailed transitions the current cycleNodeRequest to failed
 func (t *CycleNodeRequestTransitioner) transitionToFailed(err error) (reconcile.Result, error) {
+	// Block transitioning to Failed twice in a row
+	if t.cycleNodeRequest.Status.Phase == v1.CycleNodeRequestFailed {
+		return reconcile.Result{}, nil
+	}
+
 	return t.transitionToUnsuccessful(v1.CycleNodeRequestFailed, err)
 }
 

--- a/pkg/generation/cnr.go
+++ b/pkg/generation/cnr.go
@@ -3,8 +3,10 @@ package generation
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	atlassianv1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
@@ -27,8 +29,10 @@ func ListCNRs(c client.Client, options *client.ListOptions) (*atlassianv1.CycleN
 func ApplyCNR(c client.Client, drymode bool, cnr atlassianv1.CycleNodeRequest) error {
 	// Protect against failure case where cyclops checks for leftover CycleNodeStatus objects using the CycleNodeRequest name in the label selector
 	// Label values must be no more than 63 characters long
-	if len(cnr.Name) > 63 {
-		return fmt.Errorf("cnr name must be no more than 63 characters")
+	validationErrors := validation.IsDNS1035Label(cnr.Name)
+
+	if len(validationErrors) > 0 {
+		return fmt.Errorf(strings.Join(validationErrors, ","))
 	}
 
 	var dryruns []string

--- a/pkg/generation/cnr.go
+++ b/pkg/generation/cnr.go
@@ -25,7 +25,7 @@ func ListCNRs(c client.Client, options *client.ListOptions) (*atlassianv1.CycleN
 
 // ApplyCNR takes a cnr and optionally uses dry mode in the create request
 func ApplyCNR(c client.Client, drymode bool, cnr atlassianv1.CycleNodeRequest) error {
-	// Protect against failure case where cyclops checks for leftover CycleNodeStatuses using the CycleNodeRequest name in the label selector
+	// Protect against failure case where cyclops checks for leftover CycleNodeStatus objects using the CycleNodeRequest name in the label selector
 	// Label values must be no more than 63 characters long
 	if len(cnr.Name) > 63 {
 		return fmt.Errorf("cnr name must be no more than 63 characters")

--- a/pkg/generation/cnr.go
+++ b/pkg/generation/cnr.go
@@ -25,6 +25,12 @@ func ListCNRs(c client.Client, options *client.ListOptions) (*atlassianv1.CycleN
 
 // ApplyCNR takes a cnr and optionally uses dry mode in the create request
 func ApplyCNR(c client.Client, drymode bool, cnr atlassianv1.CycleNodeRequest) error {
+	// Protect against failure case where cyclops checks for leftover CycleNodeStatuses using the CycleNodeRequest name in the label selector
+	// Label values must be no more than 63 characters long
+	if len(cnr.Name) > 63 {
+		return fmt.Errorf("cnr name must be no more than 63 characters")
+	}
+
 	var dryruns []string
 	if drymode {
 		dryruns = []string{"All"}

--- a/pkg/notifications/slack/slack.go
+++ b/pkg/notifications/slack/slack.go
@@ -66,7 +66,11 @@ func (n *notifier) generateThreadMessage(cnr *v1.CycleNodeRequest) slackapi.Atta
 	}
 
 	nodeGroupTitle := "Nodegroup"
-	nodeGroupList := append([]string{cnr.Spec.NodeGroupName}, cnr.Spec.NodeGroupsList...)
+	nodeGroupList := cnr.Spec.NodeGroupsList
+
+	if cnr.Spec.NodeGroupName != "" {
+		nodeGroupList = append([]string{cnr.Spec.NodeGroupName}, nodeGroupList...)
+	}
 
 	// If there are multiple nodegroups, adjust the title
 	if (cnr.Spec.NodeGroupName != "" && len(cnr.Spec.NodeGroupsList) > 0) || len(cnr.Spec.NodeGroupsList) > 1 {

--- a/pkg/notifications/slack/slack.go
+++ b/pkg/notifications/slack/slack.go
@@ -125,9 +125,11 @@ func (n *notifier) PhaseTransitioned(cnr *v1.CycleNodeRequest) error {
 	if cnr.Status.Phase == v1.CycleNodeRequestFailed {
 		message := n.generateThreadMessage(cnr)
 
-		message.Blocks.BlockSet = append(message.Blocks.BlockSet, []slackapi.Block{
-			slackapi.NewSectionBlock(slackapi.NewTextBlockObject(markdownType, fmt.Sprintf("```%v```", cnr.Status.Message), false, false), nil, nil),
-		}...)
+		if cnr.Status.Message != "" {
+			message.Blocks.BlockSet = append(message.Blocks.BlockSet, []slackapi.Block{
+				slackapi.NewSectionBlock(slackapi.NewTextBlockObject(markdownType, fmt.Sprintf("```%v```", cnr.Status.Message), false, false), nil, nil),
+			}...)
+		}
 
 		if _, _, _, err := n.client.UpdateMessage(n.channelID, cnr.Status.ThreadTimestamp, slackapi.MsgOptionAttachments(message)); err != nil {
 			return err


### PR DESCRIPTION
- Fixes flip-flopping behaviour when a `CNS` object times out due to a pod not getting drained. I added an explicit check for failed because the other option would have been to remove the label added by cyclops to the node, which I think should remain when it fails, as with other failure cases. Additionally, since `reapChildren` is indirectly called by `transitionFailed`, there should be not possibility of transitioning back to `Healing`.
- Fixes the transition to `Failed` loop by checking if the current and desired phases are the same when transitioning to Failed. If it is the case, it stops requeueing.
- Adds a check when creating a `CNR` object to make sure that the name is no longer than 63 characters to prevent creating/listing `CNS` objects with it as a label, which kubernetes explicitly does not support.
- Fixes small visual bug with the `Nodegroups` section in the slack status message. Fixes another to remove the stylised code section when no final error message is exists.