### PR TITLE
Cut v1.2.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.1.1
+VERSION = 1.1.2
 IMAGE = cyclops:$(VERSION)
 
 MANAGER_BIN = cyclops

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.1.2
+VERSION = 1.2.0
 IMAGE = cyclops:$(VERSION)
 
 MANAGER_BIN = cyclops


### PR DESCRIPTION
Branch build "e27f8f2" has been soaking on internal clusters for quite some time now.
Cutting a new release