### PR TITLE
this commit fixes #28

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -31,33 +31,35 @@ var (
 
 // app type holds options for the application from cobra
 type app struct {
-	namespaces        *[]string
-	cloudProviderName *string
-	namespace         *string
-	addr              *string
-	prometheusAddress *string
-	dryMode           *bool
-	runImmediately    *bool
-	runOnce           *bool
-	checkInterval     *time.Duration
-	waitInterval      *time.Duration
-	nodeStartupTime   *time.Duration
+	namespaces               *[]string
+	cloudProviderName        *string
+	namespace                *string
+	addr                     *string
+	prometheusAddress        *string
+	dryMode                  *bool
+	runImmediately           *bool
+	runOnce                  *bool
+	checkInterval            *time.Duration
+	waitInterval             *time.Duration
+	nodeStartupTime          *time.Duration
+	prometheusScrapeInterval *time.Duration
 }
 
 // newApp creates a new app and sets up the cobra flags
 func newApp(rootCmd *cobra.Command) *app {
 	return &app{
-		addr:              rootCmd.PersistentFlags().String("addr", ":8080", "Address to listen on for /metrics"),
-		cloudProviderName: rootCmd.PersistentFlags().String("cloud-provider", "aws", "Which cloud provider to use, options: [aws]"),
-		namespaces:        rootCmd.PersistentFlags().StringSlice("namespaces", []string{"kube-system"}, "Namespaces to watch for cycle request objects"),
-		namespace:         rootCmd.PersistentFlags().String("namespace", "kube-system", "Namespaces to watch and create cnrs"),
-		dryMode:           rootCmd.PersistentFlags().Bool("dry", false, "api-server drymode for applying CNRs"),
-		waitInterval:      rootCmd.PersistentFlags().Duration("wait-interval", 2*time.Minute, "duration to wait after detecting changes before creating CNR objects. The window for letting changes on nodegroups settle before starting rotation"),
-		checkInterval:     rootCmd.PersistentFlags().Duration("check-interval", 5*time.Minute, `duration interval to check for changes. e.g. run the loop every 5 minutes"`),
-		nodeStartupTime:   rootCmd.PersistentFlags().Duration("node-startup-time", 2*time.Minute, "duration to wait after a cluster-autoscaler scaleUp event is detected"),
-		runImmediately:    rootCmd.PersistentFlags().Bool("now", false, "makes the check loop run straight away on program start rather than wait for the check interval to elapse"),
-		runOnce:           rootCmd.PersistentFlags().Bool("once", false, "run the check loop once then exit. also works with --now"),
-		prometheusAddress: rootCmd.PersistentFlags().String("prometheus-address", "prometheus", "Prometheus service address used to query cluster-autoscaler metrics"),
+		addr:                     rootCmd.PersistentFlags().String("addr", ":8080", "Address to listen on for /metrics"),
+		cloudProviderName:        rootCmd.PersistentFlags().String("cloud-provider", "aws", "Which cloud provider to use, options: [aws]"),
+		namespaces:               rootCmd.PersistentFlags().StringSlice("namespaces", []string{"kube-system"}, "Namespaces to watch for cycle request objects"),
+		namespace:                rootCmd.PersistentFlags().String("namespace", "kube-system", "Namespaces to watch and create cnrs"),
+		dryMode:                  rootCmd.PersistentFlags().Bool("dry", false, "api-server drymode for applying CNRs"),
+		waitInterval:             rootCmd.PersistentFlags().Duration("wait-interval", 2*time.Minute, "duration to wait after detecting changes before creating CNR objects. The window for letting changes on nodegroups settle before starting rotation"),
+		checkInterval:            rootCmd.PersistentFlags().Duration("check-interval", 5*time.Minute, `duration interval to check for changes. e.g. run the loop every 5 minutes"`),
+		nodeStartupTime:          rootCmd.PersistentFlags().Duration("node-startup-time", 2*time.Minute, "duration to wait after a cluster-autoscaler scaleUp event is detected"),
+		runImmediately:           rootCmd.PersistentFlags().Bool("now", false, "makes the check loop run straight away on program start rather than wait for the check interval to elapse"),
+		runOnce:                  rootCmd.PersistentFlags().Bool("once", false, "run the check loop once then exit. also works with --now"),
+		prometheusAddress:        rootCmd.PersistentFlags().String("prometheus-address", "prometheus", "Prometheus service address used to query cluster-autoscaler metrics"),
+		prometheusScrapeInterval: rootCmd.PersistentFlags().Duration("prometheus-scrape-interval", 40*time.Second, "Prometheus scrape interval used to detect change of value from prometheus query, needed to detect scaleUp event"),
 	}
 }
 
@@ -114,15 +116,16 @@ func (a *app) run() {
 	}
 
 	options := observer.Options{
-		CNRPrefix:         "observer",
-		Namespace:         *a.namespace,
-		CheckInterval:     *a.checkInterval,
-		DryMode:           *a.dryMode,
-		RunImmediately:    *a.runImmediately,
-		RunOnce:           *a.runOnce,
-		WaitInterval:      *a.waitInterval,
-		NodeStartupTime:   *a.nodeStartupTime,
-		PrometheusAddress: *a.prometheusAddress,
+		CNRPrefix:                "observer",
+		Namespace:                *a.namespace,
+		CheckInterval:            *a.checkInterval,
+		DryMode:                  *a.dryMode,
+		RunImmediately:           *a.runImmediately,
+		RunOnce:                  *a.runOnce,
+		WaitInterval:             *a.waitInterval,
+		NodeStartupTime:          *a.nodeStartupTime,
+		PrometheusAddress:        *a.prometheusAddress,
+		PrometheusScrapeInterval: *a.prometheusScrapeInterval,
 	}
 
 	go awaitStopSignal(stopCh)

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -189,27 +189,31 @@ Usage:
   cyclops-observer [flags]
 
 Flags:
-      --add_dir_header                   If true, adds the file directory to the header
-      --addr string                      Address to listen on for /metrics (default ":8080")
-      --alsologtostderr                  log to standard error as well as files
-      --check-interval duration          duration interval to check for changes. e.g. run the loop every 5 minutes" (default 5m0s)
-      --cloud-provider string            Which cloud provider to use, options: [aws] (default "aws")
-      --dry                              api-server drymode for applying CNRs
-  -h, --help                             help for cyclops-observer
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --namespace string                 Namespaces to watch and create cnrs (default "kube-system")
-      --namespaces strings               Namespaces to watch for outdated daemonsets (default [kube-system])
-      --run-immediately                  makes the check loop run straight away on program start rather than wait for the cron
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
-      --wait-interval duration           duration to wait after detecting changes before creating CNR objects. The window for letting changes on nodegroups settle before starting rotation (default 2m0s)
+      --add_dir_header                        If true, adds the file directory to the header
+      --addr string                           Address to listen on for /metrics (default ":8080")
+      --alsologtostderr                       log to standard error as well as files
+      --check-interval duration               duration interval to check for changes. e.g. run the loop every 5 minutes" (default 5m0s)
+      --cloud-provider string                 Which cloud provider to use, options: [aws] (default "aws")
+      --dry                                   api-server drymode for applying CNRs
+  -h, --help                                  help for cyclops-observer
+      --log_backtrace_at traceLocation        when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                        If non-empty, write log files in this directory
+      --log_file string                       If non-empty, use this log file
+      --log_file_max_size uint                Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                           log to standard error instead of files (default true)
+      --namespace string                      Namespaces to watch and create cnrs (default "kube-system")
+      --namespaces strings                    Namespaces to watch for cycle request objects (default [kube-system])
+      --node-startup-time duration            duration to wait after a cluster-autoscaler scaleUp event is detected (default 2m0s)
+      --now                                   makes the check loop run straight away on program start rather than wait for the check interval to elapse
+      --once                                  run the check loop once then exit. also works with --now
+      --prometheus-address string             Prometheus service address used to query cluster-autoscaler metrics (default "prometheus")
+      --prometheus-scrape-interval duration   Prometheus scrape interval used to detect change of value from prometheus query, needed to detect scaleUp event (default 40s)
+      --skip_headers                          If true, avoid header prefixes in the log messages
+      --skip_log_headers                      If true, avoid headers when opening log files
+      --stderrthreshold severity              logs at or above this threshold go to stderr
+  -v, --v Level                               number for the log level verbosity (default 0)
+      --vmodule moduleSpec                    comma-separated list of pattern=N settings for file-filtered logging
+      --wait-interval duration                duration to wait after detecting changes before creating CNR objects. The window for letting changes on nodegroups settle before starting rotation (default 2m0s)
 ```
 
 ### Diagram

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -300,11 +300,11 @@ func (c *controller) safeToStartCycle() bool {
 	// cluster_autoscaler_last_activity values will update every ~30 seconds in non-scaling scenario
 	// set threshold detection time to 40 seconds to take account for any anomaly that may put a slightly longer time
 	lastScaleEvent := time.Since(t)
-	if lastScaleEvent > (time.Second * 40) {
+	if lastScaleEvent > time.Second*40 {
 		klog.Infoln("Scale up event recently happened")
 		return false
 	}
-	klog.Infoln("No scale up event")
+	klog.V(3).Infoln("No scale up event")
 
 	return true
 }

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -272,7 +272,8 @@ func (c *controller) safeToStartCycle() bool {
 	v1api := promv1.NewAPI(client)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result, warnings, err := v1api.Query(ctx, "cluster_autoscaler_last_activity{activity='scaleUp'}", time.Now())
+	// scaleDown metric will stops updating and report the last time it's updated when the cluster is scaling up
+	result, warnings, err := v1api.Query(ctx, "cluster_autoscaler_last_activity{activity='scaleDown'}", time.Now())
 	if err != nil {
 		// cluster-autoscaler might not be installed in the cluster. return true if it can't find the metrics of run the query
 		klog.Errorln("Error querying Prometheus:", err)
@@ -283,9 +284,9 @@ func (c *controller) safeToStartCycle() bool {
 	}
 
 	v := result.(model.Vector)
-	// consider safe if there isn't any scaleUp event yet
+	// cluster-autoscaler should always gives a response if it's active
 	if v.Len() == 0 {
-		klog.Infoln("No scaleUp events")
+		klog.Errorln("Empty response from prometheus")
 		return true
 	}
 
@@ -296,11 +297,14 @@ func (c *controller) safeToStartCycle() bool {
 		return false
 	}
 
+	// cluster_autoscaler_last_activity values will update every ~30 seconds in non-scaling scenario
+	// set threshold detection time to 40 seconds to take account for any anomaly that may put a slightly longer time
 	lastScaleEvent := time.Since(t)
-	if lastScaleEvent <= c.NodeStartupTime {
+	if lastScaleEvent > (time.Second * 40) {
 		klog.Infoln("Scale up event recently happened")
 		return false
 	}
+	klog.Infoln("No scale up event")
 
 	return true
 }

--- a/pkg/observer/types.go
+++ b/pkg/observer/types.go
@@ -30,9 +30,10 @@ type Options struct {
 	RunImmediately bool
 	RunOnce        bool
 
-	CheckInterval   time.Duration
-	WaitInterval    time.Duration
-	NodeStartupTime time.Duration
+	CheckInterval            time.Duration
+	WaitInterval             time.Duration
+	NodeStartupTime          time.Duration
+	PrometheusScrapeInterval time.Duration
 }
 
 // ListedNodeGroups defines a type that contains a NodeGroup, a List of Nodes for that NodeGroup, and an optional Reason for why they are there


### PR DESCRIPTION
- Use `cluster_autoscaler_last_activity{activity='scaleDown'}` instead of `cluster_autoscaler_last_activity{activity='scaleUp'}`
- Change the scale up avoidance logic to detect a scale up event when the cluster-autoscaler no longer do any "check if scale down is needed" for more than 40 seconds (the average time gap per check loop is 30 seconds)
- Fixes a few comments to reflect the new change