### PR TITLE
Stability and health check fixes

### DIFF
--- a/pkg/controller/cyclenoderequest/transitioner/healthchecks.go
+++ b/pkg/controller/cyclenoderequest/transitioner/healthchecks.go
@@ -65,7 +65,7 @@ func healthCheckPassed(healthCheck v1.HealthCheck, statusCode uint, body []byte)
 	}
 
 	if healthCheck.RegexMatch != "" && !r.Match(body) {
-		return fmt.Errorf("regex %s did not match body %b", healthCheck.RegexMatch, body)
+		return fmt.Errorf("regex %s did not match body %s", healthCheck.RegexMatch, string(body))
 	}
 
 	for _, validStatusCode := range healthCheck.ValidStatusCodes {

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -279,6 +279,10 @@ func (t *CycleNodeRequestTransitioner) transitionToUnsuccessful(phase v1.CycleNo
 	t.cycleNodeRequest.Status.Phase = phase
 	// don't try to append message if it's nil
 	if err != nil {
+		if t.cycleNodeRequest.Status.Message != "" {
+			t.cycleNodeRequest.Status.Message += ", "
+		}
+
 		t.cycleNodeRequest.Status.Message += err.Error()
 	}
 


### PR DESCRIPTION
- Added a check in the `Initialised` phase to ensure a node is part of the ASG before getting it's nodegroup name
- Return the body of the health check as a string in the cyclops failed cycle error message
- If multiple errors are returned, separate them with a comma