### PR TITLE
Verify minimum compatible client version before cycling a node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 VERSION = 1.7.1
+# IMPORTANT! Update this version if changes to controller affect objects created by cli
+MINIMAL_COMPATIBLE_CLIENT_VERSION = 1.7.1
 IMAGE = cyclops:$(VERSION)
 ARCH=$(if $(TARGETPLATFORM),$(lastword $(subst /, ,$(TARGETPLATFORM))),amd64)
+BASE_PACKAGE = github.com/atlassian-labs/cyclops/pkg
+OBSERVER_BUILD_LD_FLAGS = -X 'main.version=${VERSION}' -X '${BASE_PACKAGE}/observer.version=${VERSION}'
+MANAGER_BUILD_LD_FLAGS = -X 'main.version=${VERSION}' -X '${BASE_PACKAGE}/controller/cyclenoderequest.minimalCompatibleClientVersion=${MINIMAL_COMPATIBLE_CLIENT_VERSION}'
 
 MANAGER_BIN = cyclops
 CLI_BIN = kubectl-cycle
@@ -13,10 +18,10 @@ install-cli:
 	go build -o ${GOPATH}/bin/${CLI_BIN} -ldflags="-X main.version=${VERSION}" cmd/cli/main.go
 
 build-observer:
-	go build -o bin/${OBSERVER_BIN} -ldflags="-X main.version=${VERSION}" cmd/observer/main.go
+	go build -o bin/${OBSERVER_BIN} -ldflags="${OBSERVER_BUILD_LD_FLAGS}" cmd/observer/main.go
 
 build-manager:
-	go build -o bin/${MANAGER_BIN} -ldflags="-X main.version=${VERSION}" cmd/manager/main.go
+	go build -o bin/${MANAGER_BIN} -ldflags="${MANAGER_BUILD_LD_FLAGS}" cmd/manager/main.go
 
 build-cli:
 	go build -o bin/${CLI_BIN} -ldflags="-X main.version=${VERSION}" cmd/cli/main.go
@@ -24,13 +29,13 @@ build-cli:
 build: build-manager build-cli build-observer
 
 build-manager-linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${MANAGER_BIN} -ldflags="-X main.version=${VERSION}" cmd/manager/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${MANAGER_BIN} -ldflags="${MANAGER_BUILD_LD_FLAGS}" cmd/manager/main.go
 
 build-cli-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${CLI_BIN} -ldflags="-X main.version=${VERSION}" cmd/cli/main.go
 
 build-observer-linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${OBSERVER_BIN} -ldflags="-X main.version=${VERSION}" cmd/observer/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${OBSERVER_BIN} -ldflags="${OBSERVER_BUILD_LD_FLAGS}" cmd/observer/main.go
 
 build-linux: build-manager-linux build-cli-linux build-observer-linux
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 VERSION = 1.7.1
-# IMPORTANT! Update this version if changes to controller affect CNR
-MINIMAL_COMPATIBLE_CLIENT_VERSION = 1.7.1
+# IMPORTANT! Update api version if a new release affects cnr
+API_VERSION = 1.0.0
 IMAGE = cyclops:$(VERSION)
 ARCH=$(if $(TARGETPLATFORM),$(lastword $(subst /, ,$(TARGETPLATFORM))),amd64)
 BASE_PACKAGE = github.com/atlassian-labs/cyclops/pkg
-OBSERVER_BUILD_LD_FLAGS = -X 'main.version=${VERSION}' -X '${BASE_PACKAGE}/observer.version=${VERSION}'
-MANAGER_BUILD_LD_FLAGS = -X 'main.version=${VERSION}' -X '${BASE_PACKAGE}/controller/cyclenoderequest.minimalCompatibleClientVersion=${MINIMAL_COMPATIBLE_CLIENT_VERSION}'
+CLI_BUILD_LD_FLAGS= -X 'main.version=${VERSION}' -X '${BASE_PACKAGE}/cli.apiVersion=${API_VERSION}'
+OBSERVER_BUILD_LD_FLAGS = -X 'main.version=${VERSION}' -X '${BASE_PACKAGE}/observer.apiVersion=${API_VERSION}'
+MANAGER_BUILD_LD_FLAGS = -X 'main.version=${VERSION}' -X '${BASE_PACKAGE}/controller/cyclenoderequest.apiVersion=${API_VERSION}'
 
 MANAGER_BIN = cyclops
 CLI_BIN = kubectl-cycle
@@ -15,7 +16,7 @@ OBSERVER_BIN = observer
 .DEFAULT_GOAL := build
 
 install-cli:
-	go build -o ${GOPATH}/bin/${CLI_BIN} -ldflags="-X main.version=${VERSION}" cmd/cli/main.go
+	go build -o ${GOPATH}/bin/${CLI_BIN} -ldflags="${CLI_BUILD_LD_FLAGS}" cmd/cli/main.go
 
 build-observer:
 	go build -o bin/${OBSERVER_BIN} -ldflags="${OBSERVER_BUILD_LD_FLAGS}" cmd/observer/main.go
@@ -24,7 +25,7 @@ build-manager:
 	go build -o bin/${MANAGER_BIN} -ldflags="${MANAGER_BUILD_LD_FLAGS}" cmd/manager/main.go
 
 build-cli:
-	go build -o bin/${CLI_BIN} -ldflags="-X main.version=${VERSION}" cmd/cli/main.go
+	go build -o bin/${CLI_BIN} -ldflags="${CLI_BUILD_LD_FLAGS}" cmd/cli/main.go
 
 build: build-manager build-cli build-observer
 
@@ -32,7 +33,7 @@ build-manager-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${MANAGER_BIN} -ldflags="${MANAGER_BUILD_LD_FLAGS}" cmd/manager/main.go
 
 build-cli-linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${CLI_BIN} -ldflags="-X main.version=${VERSION}" cmd/cli/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${CLI_BIN} -ldflags="${CLI_BUILD_LD_FLAGS}" cmd/cli/main.go
 
 build-observer-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -a -installsuffix cgo -o bin/linux/${OBSERVER_BIN} -ldflags="${OBSERVER_BUILD_LD_FLAGS}" cmd/observer/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION = 1.7.1
-# IMPORTANT! Update this version if changes to controller affect objects created by cli
+# IMPORTANT! Update this version if changes to controller affect CNR
 MINIMAL_COMPATIBLE_CLIENT_VERSION = 1.7.1
 IMAGE = cyclops:$(VERSION)
 ARCH=$(if $(TARGETPLATFORM),$(lastword $(subst /, ,$(TARGETPLATFORM))),amd64)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/client-go v0.22.6
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.10.0
+	github.com/hashicorp/go-version v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
+github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/pkg/cli/cycle.go
+++ b/pkg/cli/cycle.go
@@ -24,6 +24,9 @@ const (
 	separator = "«─»"
 )
 
+// replaced by ldflags at buildtime
+var apiVersion = "undefined" //nolint:golint,varcheck,deadcode,unused
+
 // cycle contains the logic and state to run as a kubectl plugin to cycle nodes
 type cycle struct {
 	plug    *kubeplug.Plug
@@ -185,7 +188,7 @@ func (c *cycle) generateCNRs(nodeGroups *atlassianv1.NodeGroupList, name, namesp
 	for _, nodeGroup := range nodeGroups.Items {
 		cnr := generation.GenerateCNR(nodeGroup, c.nodesOverride(), name, namespace)
 		generation.GiveReason(&cnr, "cli")
-		generation.GiveClientVersion(&cnr, c.version)
+		generation.SetAPIVersion(&cnr, apiVersion)
 
 		if name == "" {
 			generation.UseGenerateNameCNR(&cnr)

--- a/pkg/cli/cycle.go
+++ b/pkg/cli/cycle.go
@@ -185,6 +185,7 @@ func (c *cycle) generateCNRs(nodeGroups *atlassianv1.NodeGroupList, name, namesp
 	for _, nodeGroup := range nodeGroups.Items {
 		cnr := generation.GenerateCNR(nodeGroup, c.nodesOverride(), name, namespace)
 		generation.GiveReason(&cnr, "cli")
+		generation.GiveClientVersion(&cnr, c.version)
 
 		if name == "" {
 			generation.UseGenerateNameCNR(&cnr)

--- a/pkg/generation/cnr.go
+++ b/pkg/generation/cnr.go
@@ -3,6 +3,7 @@ package generation
 import (
 	"context"
 	"fmt"
+	"github.com/atlassian-labs/cyclops/pkg/controller/cyclenoderequest"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,6 +72,13 @@ func GiveReason(cnr *atlassianv1.CycleNodeRequest, reason string) {
 		cnr.Annotations = map[string]string{}
 	}
 	cnr.Annotations[cnrReasonAnnotationKey] = reason
+}
+
+func GiveClientVersion(cnr *atlassianv1.CycleNodeRequest, clientVersion string){
+	if cnr.Annotations == nil {
+		cnr.Annotations = map[string]string{}
+	}
+	cnr.Annotations[cyclenoderequest.ClientVersionAnnotation] = clientVersion
 }
 
 // GenerateCNR creates a setup CNR from a NodeGroup with the specified params

--- a/pkg/generation/cnr.go
+++ b/pkg/generation/cnr.go
@@ -73,12 +73,12 @@ func GiveReason(cnr *atlassianv1.CycleNodeRequest, reason string) {
 	}
 	cnr.Annotations[cnrReasonAnnotationKey] = reason
 }
-
-func GiveClientVersion(cnr *atlassianv1.CycleNodeRequest, clientVersion string){
+// SetAPIVersion adds apiVersion annotation to the cnr
+func SetAPIVersion(cnr *atlassianv1.CycleNodeRequest, clientVersion string){
 	if cnr.Annotations == nil {
 		cnr.Annotations = map[string]string{}
 	}
-	cnr.Annotations[cyclenoderequest.ClientVersionAnnotation] = clientVersion
+	cnr.Annotations[cyclenoderequest.ClientAPIVersionAnnotation] = clientVersion
 }
 
 // GenerateCNR creates a setup CNR from a NodeGroup with the specified params

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -22,6 +22,8 @@ import (
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
+var version = "undefined" //nolint:golint,varcheck,deadcode,unused
+
 // controller implements the Controller interface for running observers to detect changes and creating CNRs
 type controller struct {
 	client     client.Client
@@ -321,6 +323,7 @@ func (c *controller) createCNRs(changedNodeGroups []*ListedNodeGroups) {
 		cnr := generation.GenerateCNR(*nodeGroup.NodeGroup, nodeNames, c.CNRPrefix, c.Namespace)
 		generation.UseGenerateNameCNR(&cnr)
 		generation.GiveReason(&cnr, nodeGroup.Reason)
+		generation.GiveClientVersion(&cnr, version)
 
 		name := generation.GetName(cnr.ObjectMeta)
 

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -22,7 +22,7 @@ import (
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
-var version = "undefined" //nolint:golint,varcheck,deadcode,unused
+var apiVersion = "undefined" //nolint:golint,varcheck,deadcode,unused
 
 // controller implements the Controller interface for running observers to detect changes and creating CNRs
 type controller struct {
@@ -323,7 +323,7 @@ func (c *controller) createCNRs(changedNodeGroups []*ListedNodeGroups) {
 		cnr := generation.GenerateCNR(*nodeGroup.NodeGroup, nodeNames, c.CNRPrefix, c.Namespace)
 		generation.UseGenerateNameCNR(&cnr)
 		generation.GiveReason(&cnr, nodeGroup.Reason)
-		generation.GiveClientVersion(&cnr, version)
+		generation.SetAPIVersion(&cnr, apiVersion)
 
 		name := generation.GetName(cnr.ObjectMeta)
 


### PR DESCRIPTION
This PR adds a few modifications to client and cyclops controller logic, namely:

* local client will create cnr with an annotation client.api.version=$version
* cyclops controller will read cnr metadata and if exists compare it to a its own client.api.version version
* if there's version mismatch crn status is set to failed and a message is added too
* observer controller creates cnrs with an annotation value retrieved a var that gets its value at build time

Example CNR from a local test where cycle cli was built with a 1.7.0 version:

```
apiVersion: atlassian.com/v1
kind: CycleNodeRequest
metadata:
  annotations:
    client.api.version: 1.0.0
    reason: cli
  generateName: system-
  generation: 2
  name: system-dk5bk
  namespace: kube-system
spec:
  cycleSettings:
    concurrency: 1
    labelsToRemove:
    - coredns-active
    method: Drain
  nodeGroupName: ""
  nodeGroupsList:
  - system.x.x.x.x.x
  selector:
    matchLabels:
      customer: kitt
      role: node
status:
  message: Client API version 0.0.1 does not match controller API version 1.0.0
  phase: Failed
```
Tested cns created by observer. The CNR is created with an annotation which is then validated by cyclops controller.

```
apiVersion: atlassian.com/v1
kind: CycleNodeRequest
metadata:
  annotations:
    client.api.version: 1.0.0
    reason: |-
      instance "i-0be5c478d246b2760" / node "ip-x.x.x.x" not up to date with current cloud provider node group configuration/template
 ```