### PR TITLE
make pre-termination checks concurrent

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,5 +15,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.30
+          version: v1.45
           args: --timeout=5m

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -1,10 +1,12 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -32,6 +34,15 @@ func UncordonNode(name string, client kubernetes.Interface) error {
 		},
 	}
 	return PatchNode(name, patches, client)
+}
+
+// IsCordoned checks if a node is cordoned
+func IsCordoned(name string, client kubernetes.Interface) (bool, error) {
+	node, err := client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	return node.Spec.Unschedulable, nil
 }
 
 // AddLabelToNode performs a patch operation on a node to add a label to the node


### PR DESCRIPTION
Previously, pre-termination checks in cyclops did not occur concurrently, they ran in sequence when multiple nodes are cycled together.

Now they are run concurrently.

Tested in lab.

Also bump version of golangci-lint so that it uses the correct version of go and not run into [this error](https://github.com/atlassian-labs/cyclops/runs/6104105327?check_suite_focus=true)