### PR TITLE
Skip cycling if nodes are up to date with ASG

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,5 +15,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.30
+          version: v1.45
           args: --timeout=5m

--- a/pkg/apis/atlassian/v1/cyclenoderequest_types.go
+++ b/pkg/apis/atlassian/v1/cyclenoderequest_types.go
@@ -165,6 +165,9 @@ const (
 
 	// CycleNodeRequestHealing is for the state before Failing where cyclops will try to put the cluster back in a consistent state
 	CycleNodeRequestHealing CycleNodeRequestPhase = "Healing"
+
+	// CycleNodeRequestSkipped is for the state when there are no changes between nodegroup config and its respective AGS in cloud provider
+	CycleNodeRequestSkipped CycleNodeRequestPhase = "Skipped"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/cyclenoderequest/transitioner/transitioner.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitioner.go
@@ -91,6 +91,7 @@ func (t *CycleNodeRequestTransitioner) transitionFuncs() map[v1.CycleNodeRequest
 		v1.CycleNodeRequestWaitingTermination: t.transitionWaitingTermination,
 		v1.CycleNodeRequestFailed:             t.transitionFailed,
 		v1.CycleNodeRequestSuccessful:         t.transitionSuccessful,
+		v1.CycleNodeRequestSkipped:			   t.transitionSkipped,
 		v1.CycleNodeRequestHealing:            t.transitionHealing,
 	}
 }

--- a/pkg/controller/cyclenoderequest/transitioner/transitioner.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitioner.go
@@ -91,7 +91,7 @@ func (t *CycleNodeRequestTransitioner) transitionFuncs() map[v1.CycleNodeRequest
 		v1.CycleNodeRequestWaitingTermination: t.transitionWaitingTermination,
 		v1.CycleNodeRequestFailed:             t.transitionFailed,
 		v1.CycleNodeRequestSuccessful:         t.transitionSuccessful,
-		v1.CycleNodeRequestSkipped:			   t.transitionSkipped,
+		v1.CycleNodeRequestSkipped:            t.transitionSkipped,
 		v1.CycleNodeRequestHealing:            t.transitionHealing,
 	}
 }

--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -3,6 +3,7 @@ package transitioner
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -110,8 +111,8 @@ func (t *CycleNodeRequestTransitioner) transitionPending() (reconcile.Result, er
 	// get instances inside cloud provider node groups
 	nodeGroupInstances := nodeGroups.Instances()
 
-	forceCheckAsgConfigAnnotations := t.cycleNodeRequest.Annotations[ForceAsgConfigCheckAnnotation]
-	if forceCheckAsgConfigAnnotations == "true" {
+	forceCheckAsgConfigAnnotations, _ := strconv.ParseBool(t.cycleNodeRequest.Annotations[ForceAsgConfigCheckAnnotation])
+	if forceCheckAsgConfigAnnotations {
 		var skipped = true
 		for _, instance := range nodeGroupInstances {
 			outOfDate := instance.OutOfDate()

--- a/pkg/generation/cnr.go
+++ b/pkg/generation/cnr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/atlassian-labs/cyclops/pkg/controller/cyclenoderequest"
+	"github.com/atlassian-labs/cyclops/pkg/controller/cyclenoderequest/transitioner"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,6 +80,14 @@ func SetAPIVersion(cnr *atlassianv1.CycleNodeRequest, clientVersion string){
 		cnr.Annotations = map[string]string{}
 	}
 	cnr.Annotations[cyclenoderequest.ClientAPIVersionAnnotation] = clientVersion
+}
+
+// SetForceCheckAsgConfig adds apiVersion annotation to the cnr
+func SetForceCheckAsgConfig(cnr *atlassianv1.CycleNodeRequest){
+	if cnr.Annotations == nil {
+		cnr.Annotations = map[string]string{}
+	}
+	cnr.Annotations[transitioner.ForceAsgConfigCheckAnnotation] = "true"
 }
 
 // GenerateCNR creates a setup CNR from a NodeGroup with the specified params


### PR DESCRIPTION
This PR:

* adds a flag `--force-asg-config-check` to kubectl cycle which adds `force-check-asg-config` annotation to a cnr
* instructs controller to check for an annotation (true) and check if nodes in the nodegroups are up to date with its ASG (get autoscaling group nodes and call `OutOfDate()` on them)
* if at least one node isn't up to date with ASG cycling will happen as usual
* if all nodes are up to date a cnr is transitioned into a Skipped state with a custom message saying that no node changes detected

Tested in a lab with the following scenarios

### Nodes are up to date with ASG

`kubectl cycle system --force-asg-config-check`. Results in a cnr in a Skipped state:

```
apiVersion: atlassian.com/v1
kind: CycleNodeRequest
metadata:
  annotations:
    client.api.version: 1.0.0
    force-check-asg-config: "true"
    reason: cli
  creationTimestamp: "2022-04-21T21:25:18Z"
  generateName: system-
  generation: 3
  name: system-tdw99
  namespace: kube-system
  resourceVersion: "4286259"
  uid: 06b2a92f-df7a-4d1a-96f5-fe7d558c2024
spec:
  cycleSettings:
    concurrency: 1
    labelsToRemove:
    - coredns-active
    method: Drain
  nodeGroupName: ""
  nodeGroupsList:
  - system.lab-lab5.us-west-2.kitt-inf.net
  selector:
    matchLabels:
      customer: kitt
      role: node
status:
  message: Cycling skipped because all nodes in the nodegroups are up-to-date with
    a cloud provider ASG
  phase: Skipped
```

### Nodes are not up to date with ASG

Change node init script and terraform apply to update system ASG. `kubectl cycle system --force-asg-config-check` results in all system nodes being cycled since there are changes.
