### PR TITLE
fix the order of nested for loop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ^1.15
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build
       run: make build

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,9 +11,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48
+          version: v1.51.0
           args: --timeout=5m

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	v1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
-	"github.com/atlassian-labs/cyclops/pkg/cloudprovider"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -14,6 +12,9 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
+	"github.com/atlassian-labs/cyclops/pkg/cloudprovider"
 )
 
 // transitionToHealing transitions the current cycleNodeRequest to healing which will always transiting to failed
@@ -108,7 +109,6 @@ func (t *CycleNodeRequestTransitioner) reapChildren() (v1.CycleNodeRequestPhase,
 
 	// Check all of the children - if any are failed, the whole CycleNodeRequest fails
 	inProgressCount := 0
-	reapedChildren := 0
 	for _, cycleNodeStatus := range cycleNodeStatusList.Items {
 		switch cycleNodeStatus.Status.Phase {
 		case v1.CycleNodeStatusFailed:
@@ -123,7 +123,6 @@ func (t *CycleNodeRequestTransitioner) reapChildren() (v1.CycleNodeRequestPhase,
 			if err != nil {
 				return nextPhase, err
 			}
-			reapedChildren++
 		default:
 			inProgressCount++
 		}


### PR DESCRIPTION
The order of the 2 nested `for` loop could potentially make `numNodesInProgress++` getting executed for more than once - this won't cause issue when concurrency is 1. Changed the order so that it will loop all ready nodes first. 

Also removed `reapedChildren` from `pkg/controller/cyclenoderequest/transitioner/util.go` which is not used. 

Upgraded github action versions - old versions are deprecated and caused lint job failed. 