### PR TITLE
Healing after cyclenodestatus failed

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         
       - name: Set short sha variable
         id: vars

--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -520,7 +520,7 @@ func (t *CycleNodeRequestTransitioner) transitionHealing() (reconcile.Result, er
 
 	for _, node := range t.cycleNodeRequest.Status.NodesToTerminate {
 		// nodes in NodesToTerminate may have been terminated, so check if they still exist
-		if nodeExist, err := k8s.NodeExist(node.Name, t.rm.RawClient); err != nil || !nodeExist {
+		if nodeExists, err := k8s.NodeExists(node.Name, t.rm.RawClient); err != nil || !nodeExists {
 			t.rm.LogEvent(t.cycleNodeRequest,
 				"HealingNodes", "Skip healing node: %s, err: %v",
 				node.Name, err)

--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
-	"github.com/atlassian-labs/cyclops/pkg/k8s"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
+	"github.com/atlassian-labs/cyclops/pkg/k8s"
+	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/util/retry"
@@ -517,28 +518,37 @@ func (t *CycleNodeRequestTransitioner) transitionHealing() (reconcile.Result, er
 		return t.transitionToFailed(err)
 	}
 
-	// try and re-attach the nodes, if any were un-attached
 	for _, node := range t.cycleNodeRequest.Status.NodesToTerminate {
+		// nodes in NodesToTerminate may have been terminated, so check if they still exist
+		if nodeExist, err := k8s.NodeExist(node.Name, t.rm.RawClient); err != nil || !nodeExist {
+			t.rm.LogEvent(t.cycleNodeRequest,
+				"HealingNodes", "Skip healing node: %s, err: %v",
+				node.Name, err)
+			continue
+		}
+
+		// try and re-attach the nodes, if any were un-attached
 		t.rm.LogEvent(t.cycleNodeRequest, "AttachingNodes", "Attaching instances to nodes group: %v", node.Name)
 		alreadyAttached, err := nodeGroups.AttachInstance(node.ProviderID, node.NodeGroupName)
 		if alreadyAttached {
 			t.rm.LogEvent(t.cycleNodeRequest,
 				"AttachingNodes", "Skip re-attaching instances to nodes group: %v, err: %v",
 				node.Name, err)
-			continue
 		}
 		if err != nil {
-			return t.transitionToFailed(err)
+			t.rm.LogWarningEvent(t.cycleNodeRequest,
+				"AttachingNodes", "Re-attaching instances to nodes group failed: %v, err: %v",
+				node.Name, err)
 		}
-	}
 
-	// un-cordon after attach as well
-	for _, node := range t.cycleNodeRequest.Status.NodesToTerminate {
+		// un-cordon after attach as well
 		t.rm.LogEvent(t.cycleNodeRequest, "UncordoningNodes", "Uncordoning nodes in node group: %v", node.Name)
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			return k8s.UncordonNode(node.Name, t.rm.RawClient)
 		}); err != nil {
-			return t.transitionToFailed(err)
+			t.rm.LogWarningEvent(t.cycleNodeRequest,
+				"UncordoningNodes", "Uncordoning nodes in node group failed: %v, err: %v",
+				node.Name, err)
 		}
 	}
 

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -112,7 +112,7 @@ func (t *CycleNodeRequestTransitioner) reapChildren() (v1.CycleNodeRequestPhase,
 	for _, cycleNodeStatus := range cycleNodeStatusList.Items {
 		switch cycleNodeStatus.Status.Phase {
 		case v1.CycleNodeStatusFailed:
-			nextPhase = v1.CycleNodeRequestFailed
+			nextPhase = v1.CycleNodeRequestHealing
 			t.rm.LogWarningEvent(t.cycleNodeRequest, "ReapChildren", "Failed to cycle node: %v, reason: %v", cycleNodeStatus.Spec.NodeName, cycleNodeStatus.Status.Message)
 			t.rm.Logger.Info("Child has failed", "nodeName", cycleNodeStatus.Name, "status", cycleNodeStatus.Status.Phase, "message", cycleNodeStatus.Status.Message)
 			fallthrough
@@ -143,7 +143,7 @@ func (t *CycleNodeRequestTransitioner) reapChildren() (v1.CycleNodeRequestPhase,
 	// It is assumed that nodes selected for cycling will take roughly the same time to finish
 	// Bringing up multiple nodes together will speed up the whole process as well as spread out pods properly across the new nodes
 	// If the next phase should be failed, skip this since transitioning back to initialised would be flip-flopping behaviour
-	if nextPhase != v1.CycleNodeRequestFailed && t.cycleNodeRequest.Status.ActiveChildren <= t.cycleNodeRequest.Spec.CycleSettings.Concurrency/2 {
+	if nextPhase != v1.CycleNodeRequestHealing && t.cycleNodeRequest.Status.ActiveChildren <= t.cycleNodeRequest.Spec.CycleSettings.Concurrency/2 {
 		t.rm.Logger.Info("Transition back to Initialised to grab more child nodes", "ActiveChildren", t.cycleNodeRequest.Status.ActiveChildren, "Concurrency", t.cycleNodeRequest.Spec.CycleSettings.Concurrency)
 		nextPhase = v1.CycleNodeRequestInitialised
 	}

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -98,6 +98,6 @@ func NodeExists(name string, client kubernetes.Interface) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	
+
 	return true, nil
 }

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -86,3 +86,12 @@ func (c *cachedNodeList) List(selector labels.Selector) ([]*v1.Node, error) {
 
 	return nodes, err
 }
+
+// NodeExist checks if a node exists
+func NodeExist(name string, client kubernetes.Interface) (bool, error) {
+	_, err := client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -90,8 +91,13 @@ func (c *cachedNodeList) List(selector labels.Selector) ([]*v1.Node, error) {
 // NodeExists checks if a node exists
 func NodeExists(name string, client kubernetes.Interface) (bool, error) {
 	_, err := client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+
 	if err != nil {
 		return false, err
 	}
+	
 	return true, nil
 }

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -87,8 +87,8 @@ func (c *cachedNodeList) List(selector labels.Selector) ([]*v1.Node, error) {
 	return nodes, err
 }
 
-// NodeExist checks if a node exists
-func NodeExist(name string, client kubernetes.Interface) (bool, error) {
+// NodeExists checks if a node exists
+func NodeExists(name string, client kubernetes.Interface) (bool, error) {
 	_, err := client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
When cyclenodestatus failed, cyclenoderequest should transit to Healing instead of Failed directly, so that it will try to re-attach and uncordon nodes. 

One problem with the current logic in `transitionHealing` is that some nodes may have already been terminated when it loops `NodesToTerminate`, and this will make it transit to Failed. Changed it to skip if node doesn't exist anymore, so that it will loop all nodes. 

Note: this will need to rebase from https://github.com/atlassian-labs/cyclops/pull/54 to get the updated github action versions, but I feel it'd still be better to have this as a separate PR. 

p.s. Also updated github action versions for docker. 