### PR TITLE
Fix if statement in transitionHealing

### DIFF
--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -534,12 +534,14 @@ func (t *CycleNodeRequestTransitioner) transitionHealing() (reconcile.Result, er
 		// try and re-attach the nodes, if any were un-attached
 		t.rm.LogEvent(t.cycleNodeRequest, "AttachingNodes", "Attaching instances to nodes group: %v", node.Name)
 		// if the node is already attached, ignore the error and continue to un-cordoning, otherwise return with error
-		if alreadyAttached, err := nodeGroups.AttachInstance(node.ProviderID, node.NodeGroupName); alreadyAttached {
+		alreadyAttached, err := nodeGroups.AttachInstance(node.ProviderID, node.NodeGroupName)
+		if err != nil && !alreadyAttached {
+			return t.transitionToFailed(err)
+		}
+		if alreadyAttached {
 			t.rm.LogEvent(t.cycleNodeRequest,
 				"AttachingNodes", "Skip re-attaching instances to nodes group: %v, err: %v",
 				node.Name, err)
-		} else if err != nil {
-			return t.transitionToFailed(err)
 		}
 
 		// un-cordon after attach as well

--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -524,7 +524,7 @@ func (t *CycleNodeRequestTransitioner) transitionHealing() (reconcile.Result, er
 		if err != nil {
 			return t.transitionToFailed(err)
 		}
-		
+
 		if !nodeExists {
 			t.rm.LogEvent(t.cycleNodeRequest,
 				"HealingNodes", "Node does not exist, skip healing node: %s", node.Name)
@@ -533,13 +533,12 @@ func (t *CycleNodeRequestTransitioner) transitionHealing() (reconcile.Result, er
 
 		// try and re-attach the nodes, if any were un-attached
 		t.rm.LogEvent(t.cycleNodeRequest, "AttachingNodes", "Attaching instances to nodes group: %v", node.Name)
-		alreadyAttached, err := nodeGroups.AttachInstance(node.ProviderID, node.NodeGroupName)
-		if alreadyAttached {
+		// if the node is already attached, ignore the error and continue to un-cordoning, otherwise return with error
+		if alreadyAttached, err := nodeGroups.AttachInstance(node.ProviderID, node.NodeGroupName); alreadyAttached {
 			t.rm.LogEvent(t.cycleNodeRequest,
 				"AttachingNodes", "Skip re-attaching instances to nodes group: %v, err: %v",
 				node.Name, err)
-		}
-		if err != nil {
+		} else if err != nil {
 			return t.transitionToFailed(err)
 		}
 


### PR DESCRIPTION
`AttacheInstance` returns `true` and the `"is already part of AutoScalingGroup"` error (not `nil`) when the instance is already in ASG, need to fix the if statement for this - so that when the instance is already in ASG, we ignore this error and continue healing, if there is error other than this, return with error.