### PR TITLE
handle launch template latest version in observer

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -95,7 +95,7 @@ func main() {
 	metrics.Register(mgr.GetClient(), log, *namespace)
 
 	// Setup the cloud provider
-	cloudProvider, err := builder.BuildCloudProvider(*cloudProviderName)
+	cloudProvider, err := builder.BuildCloudProvider(*cloudProviderName, logger)
 	if err != nil {
 		log.Error(err, "Unable to build cloud provider")
 		os.Exit(1)

--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
+	"k8s.io/klog/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/atlassian-labs/cyclops/pkg/apis"
@@ -27,6 +28,7 @@ import (
 var (
 	// replaced by ldflags at buildtime
 	version = "undefined" //nolint:golint,varcheck,deadcode,unused
+	klogger = klogr.New()
 )
 
 // app type holds options for the application from cobra
@@ -168,7 +170,7 @@ func (a *app) createK8SObserver(nodeLister k8s.NodeLister, podLister k8s.PodList
 // createCloudObserver creates a new cloud.Observer with the given cloud provider name
 func (a *app) createCloudObserver(nodeLister k8s.NodeLister) observer.Observer {
 	// Setup the backend cloud provider
-	cloudProvider, err := builder.BuildCloudProvider(*a.cloudProviderName)
+	cloudProvider, err := builder.BuildCloudProvider(*a.cloudProviderName, klogger)
 	if err != nil {
 		klog.Error(err, "Unable to build cloud provider")
 		os.Exit(1)

--- a/docs/deployment/cloud-providers/aws/iam_policy.json
+++ b/docs/deployment/cloud-providers/aws/iam_policy.json
@@ -8,7 +8,8 @@
         "autoscaling:DetachInstances",
         "autoscaling:AttachInstances",
         "ec2:TerminateInstances",
-        "ec2:DescribeInstances"
+        "ec2:DescribeInstances",
+        "ec2:DescribeLaunchTemplateVersions"
       ],
       "Resource": "*"
     }

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -367,7 +367,7 @@ func (a *autoscalingGroups) getLaunchTemplateLatestVersion(id string) (string, e
 	}
 
 	if len(out.LaunchTemplateVersions) == 0 {
-		return "", errors.Wrapf(err, "[ASG ]failed to get latest launch template version %q", id)
+		return "", errors.Wrapf(err, "[ASG] failed to get latest launch template version %q", id)
 	}
 
 	return strconv.Itoa(int(*out.LaunchTemplateVersions[0].VersionNumber)), nil

--- a/pkg/cloudprovider/aws/builder.go
+++ b/pkg/cloudprovider/aws/builder.go
@@ -9,13 +9,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var log = logf.Log.WithName("aws")
+var defaultLogger = logf.Log.WithName("aws")
 
 // NewCloudProvider returns a new AWS cloud provider
-func NewCloudProvider() (cloudprovider.CloudProvider, error) {
+func NewCloudProvider(logger logr.Logger) (cloudprovider.CloudProvider, error) {
 	sess, err := session.NewSession()
 	if err != nil {
 		return nil, err
@@ -26,6 +27,11 @@ func NewCloudProvider() (cloudprovider.CloudProvider, error) {
 
 	ec2Service := ec2.New(sess, config)
 	autoScalingService := autoscaling.New(sess, config)
+
+	var log = defaultLogger
+	if logger != nil {
+		log = logger
+	}
 
 	p := &provider{
 		autoScalingService: autoScalingService,

--- a/pkg/cloudprovider/builder/builder.go
+++ b/pkg/cloudprovider/builder/builder.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/atlassian-labs/cyclops/pkg/cloudprovider"
 	"github.com/atlassian-labs/cyclops/pkg/cloudprovider/aws"
+	"github.com/go-logr/logr"
 )
 
-type builderFunc func() (cloudprovider.CloudProvider, error)
+type builderFunc func(logger logr.Logger) (cloudprovider.CloudProvider, error)
 
 // BuildCloudProvider returns a cloud provider based on the provided name
-func BuildCloudProvider(name string) (cloudprovider.CloudProvider, error) {
+func BuildCloudProvider(name string, logger logr.Logger) (cloudprovider.CloudProvider, error) {
 	buildFuncs := map[string]builderFunc{
 		aws.ProviderName: aws.NewCloudProvider,
 	}
@@ -20,5 +21,5 @@ func BuildCloudProvider(name string) (cloudprovider.CloudProvider, error) {
 		return nil, fmt.Errorf("builder for cloud provider %v not found", name)
 	}
 
-	return builder()
+	return builder(logger)
 }


### PR DESCRIPTION
fixes #61 

- Resolve latest launch template version before comparing
- Test for $latest case
- Fix issue with no logs working from the cloudprovider aws package