### PR TITLE
Add a finalizer before detaching a node and don't error if a node has been deleted

### DIFF
--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -65,7 +65,6 @@ func (rm *ResourceManager) DeleteNode(name string) error {
 		return nil
 	}
 
-	// Delete the node
 	return err
 }
 

--- a/pkg/controller/node.go
+++ b/pkg/controller/node.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/atlassian-labs/cyclops/pkg/k8s"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -41,12 +43,30 @@ func (rm *ResourceManager) GetNode(name string) (*v1.Node, error) {
 func (rm *ResourceManager) DeleteNode(name string) error {
 	// Get the node
 	node, err := rm.GetNode(name)
+
+	// If the node is not found then skip trying to delete it
+	if err != nil && apierrors.IsNotFound(err) {
+		rm.Logger.Info("node already deleted, skip deleting", "node", name)
+		return nil
+	}
+
+	// Account for any other possible errors
 	if err != nil {
 		return err
 	}
 
+	// The node exists as of the previous step, try deleting it now
+	err = rm.Client.Delete(context.TODO(), node)
+
+	// Account for possible race conditions with other controllers managing
+	// nodes in the cluster
+	if apierrors.IsNotFound(err) {
+		rm.Logger.Info("node deletion attemp failed, node already deleted", "node", name)
+		return nil
+	}
+
 	// Delete the node
-	return rm.Client.Delete(context.TODO(), node)
+	return err
 }
 
 // DrainPods drains the pods off the named node.
@@ -70,4 +90,41 @@ func (rm *ResourceManager) DrainPods(nodeName string, unhealthyAfter time.Durati
 	}
 
 	return false, k8s.DrainPods(pods, rm.RawClient, unhealthyAfter)
+}
+
+func (rm *ResourceManager) AddFinalizerToNode(nodeName, finalizerName string) error {
+	return rm.manageFinalizerOnNode(nodeName, finalizerName, k8s.AddFinalizerToNode)
+}
+
+func (rm *ResourceManager) RemoveFinalizerFromNode(nodeName, finalizerName string) error {
+	return rm.manageFinalizerOnNode(nodeName, finalizerName, k8s.RemoveFinalizerFromNode)
+}
+
+func (rm *ResourceManager) manageFinalizerOnNode(nodeName, finalizerName string, fn func(*v1.Node, string, kubernetes.Interface) error) error {
+	// Get the node
+	node, err := rm.GetNode(nodeName)
+
+	// If the node is not found then skip the finalizer operation
+	if err != nil && apierrors.IsNotFound(err) {
+		rm.Logger.Info("node deleted, skip adding finalizer", "node", nodeName)
+		return nil
+	}
+
+	// Account for any other possible errors
+	if err != nil {
+		return err
+	}
+
+	// The node exists as of the previous step, try managing the finalizer for
+	// it now
+	err = fn(node, finalizerName, rm.RawClient)
+
+	// Account for possible race conditions with other controllers managing
+	// nodes in the cluster
+	if apierrors.IsNotFound(err) {
+		rm.Logger.Info("adding finalizer failed, node already deleted", "node", nodeName)
+		return nil
+	}
+
+	return err
 }

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // CordonNode performs a patch operation on a node to mark it as unschedulable
@@ -58,6 +59,20 @@ func AddLabelToNode(nodeName string, labelName string, labelValue string, client
 		},
 	}
 	return PatchNode(nodeName, patches, client)
+}
+
+// AddFinalizerToNode updates a node to add a finalizer to it
+func AddFinalizerToNode(node *v1.Node, finalizerName string, client kubernetes.Interface) error {
+	controllerutil.AddFinalizer(node, finalizerName)
+	_, err := client.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+	return err
+}
+
+// RemoveFinalizerFromNode updates a node to remove a finalizer from it
+func RemoveFinalizerFromNode(node *v1.Node, finalizerName string, client kubernetes.Interface) error {
+	controllerutil.RemoveFinalizer(node, finalizerName)
+	_, err := client.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+	return err
 }
 
 // NodeLister defines an object that can list nodes with a label selector


### PR DESCRIPTION
If another controller managed nodes and deletes a node from the cluster during a cycle when this causes Cyclops fail the CNR. There are two improvements made here to mitigate this:
1. Add a finalizer before detaching the node so that the node should not be deleted by another controller
2. Add error checks so that if a node is already deleted from the cluster then cyclops can continue and terminate it

I tested adding the checks when terminating an instance from an ASG but could not produce an error so I left it as is.