### PR TITLE
Get Slack token from file instead of environment variable

### DIFF
--- a/docs/deployment/messaging-providers/slack/README.md
+++ b/docs/deployment/messaging-providers/slack/README.md
@@ -18,13 +18,15 @@ You can now install the app to your workspace.
 
 ## Evironment Variables
 
-Cyclops will need three environment variables to successfully push notifications to Slack.
+Cyclops will need the following information to successfully push notifications to Slack:
 
-1. `SLACK_BOT_USER_OAUTH_ACCESS_TOKEN` is the auth token which can be obtained from the `Basic Information` page of your app in Slack. Make sure to copy `Bot User OAuth Access Token`.
+1. Slack Bot Token is the auth token which can be obtained from the `Basic Information` page of your app in Slack. Make sure to copy `Bot User OAuth Access Token`. You can then provide this token to Cyclops via one of the following methods: 
+   1. (Recommended) Mount the token as a file from a secret in you Kubernetes cluster, then set the `SLACK_BOT_USER_OAUTH_ACCESS_TOKEN_FILE` environment variable to the path of this file.
+   2. Alternatively, you can directly set the `SLACK_BOT_USER_OAUTH_ACCESS_TOKEN` environment variable to the token.
 
-2. `SLACK_CHANNEL_ID` is id of the channel in which you want to post your notifications. Navigate to your Slack workspace on the browser `https://<workspace>.slack.com`. Create the channel in which you want to add Cyclops. The url should be in the form `https://app.slack.com/client/<workspace_id>/<channel_id>`. Copy the channel id from the url.
+2. Environment Variable `SLACK_CHANNEL_ID` is id of the channel in which you want to post your notifications. Navigate to your Slack workspace on the browser `https://<workspace>.slack.com`. Create the channel in which you want to add Cyclops. The url should be in the form `https://app.slack.com/client/<workspace_id>/<channel_id>`. Copy the channel id from the url.
 
-3. `CLUSTER_NAME` is the name of your cluster which you will need to pass in.
+3. Environment Variable `CLUSTER_NAME` is the name of your cluster which you will need to pass in.
 
 ## Common issues, caveats and gotchas
 

--- a/pkg/notifications/slack/builder.go
+++ b/pkg/notifications/slack/builder.go
@@ -3,21 +3,28 @@ package slack
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/atlassian-labs/cyclops/pkg/notifications"
 	slackapi "github.com/slack-go/slack"
 )
 
+const (
+	slackBotUserOAuthAccessTokenFile = "SLACK_BOT_USER_OAUTH_ACCESS_TOKEN_FILE"
+	slackBotUserOAuthAccessToken     = "SLACK_BOT_USER_OAUTH_ACCESS_TOKEN"
+	slackChannelID                   = "SLACK_CHANNEL_ID"
+)
+
 // NewNotifier returns a new Slack notifier
 func NewNotifier() (notifications.Notifier, error) {
 	// Return an error is no slack oauth token is provided
-	token, ok := os.LookupEnv("SLACK_BOT_USER_OAUTH_ACCESS_TOKEN")
+	token, ok := getSlackBotToken()
 	if !ok {
 		return nil, fmt.Errorf("missing slack oauth token")
 	}
 
-	// Return an error if no slack channel is specified
-	channelID, ok := os.LookupEnv("SLACK_CHANNEL_ID")
+	// Return an error if no Slack channel is specified
+	channelID, ok := getSlackChannelID()
 	if !ok {
 		return nil, fmt.Errorf("missing slack channel id")
 	}
@@ -27,10 +34,34 @@ func NewNotifier() (notifications.Notifier, error) {
 		channelID: channelID,
 	}
 
-	// Check that the slack app has been added to the channel in the workspace
+	// Check that the Slack app has been added to the channel in the workspace
 	if _, err := n.client.GetConversationInfo(channelID, false); err != nil {
 		return nil, err
 	}
 
 	return n, nil
+}
+
+func getSlackChannelID() (string, bool) {
+	// Read channel ID from env var
+	channelID, ok := os.LookupEnv(slackChannelID)
+	return channelID, ok
+}
+
+func getSlackBotToken() (string, bool) {
+	// Check if Slack token is provided as a file, file name is provided in env var
+	tokenFile, ok := os.LookupEnv(slackBotUserOAuthAccessTokenFile)
+
+	// If env var for token file is not set, read token from env var directly
+	if !ok {
+		token, ok := os.LookupEnv(slackBotUserOAuthAccessToken)
+		return token, ok
+	}
+
+	token, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return "", false
+	}
+
+	return strings.TrimSpace(string(token)), true
 }

--- a/pkg/notifications/slack/builder.go
+++ b/pkg/notifications/slack/builder.go
@@ -44,8 +44,7 @@ func NewNotifier() (notifications.Notifier, error) {
 
 func getSlackChannelID() (string, bool) {
 	// Read channel ID from env var
-	channelID, ok := os.LookupEnv(slackChannelID)
-	return channelID, ok
+	return os.LookupEnv(slackChannelID)
 }
 
 func getSlackBotToken() (string, bool) {
@@ -54,8 +53,7 @@ func getSlackBotToken() (string, bool) {
 
 	// If env var for token file is not set, read token from env var directly
 	if !ok {
-		token, ok := os.LookupEnv(slackBotUserOAuthAccessToken)
-		return token, ok
+		return os.LookupEnv(slackBotUserOAuthAccessToken)
 	}
 
 	token, err := os.ReadFile(tokenFile)

--- a/pkg/notifications/slack/builder_test.go
+++ b/pkg/notifications/slack/builder_test.go
@@ -1,0 +1,98 @@
+package slack
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getSlackChannelID(t *testing.T) {
+	tests := []struct {
+		name     string
+		setEnv   func(t *testing.T)
+		expect   string
+		expectOk bool
+	}{
+		{
+			name: "test channel ID from env var",
+			setEnv: func(t *testing.T) {
+				t.Setenv(slackChannelID, "test_channel_id")
+			},
+			expect:   "test_channel_id",
+			expectOk: true,
+		},
+		{
+			name:     "test missing channel ID",
+			setEnv:   func(t *testing.T) {},
+			expect:   "",
+			expectOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment variables
+			tt.setEnv(t)
+
+			result, ok := getSlackChannelID()
+			assert.Equal(t, tt.expect, result)
+			assert.Equal(t, tt.expectOk, ok)
+		})
+	}
+}
+
+func Test_getSlackBotToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		setEnv   func(t *testing.T)
+		expect   string
+		expectOk bool
+	}{
+		{
+			name: "test bot token from file",
+			setEnv: func(t *testing.T) {
+				tempDir := t.TempDir()
+				file, err := os.Create(tempDir + "test_bot_token_file")
+				if err != nil {
+					fmt.Println(err)
+				}
+				defer file.Close()
+
+				if _, err = file.WriteString("test_bot_token"); err != nil {
+					fmt.Println(err)
+				}
+				t.Setenv(slackBotUserOAuthAccessTokenFile, file.Name())
+			},
+			expect:   "test_bot_token",
+			expectOk: true,
+		},
+		{
+			name: "test bot token from env var",
+			setEnv: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(slackBotUserOAuthAccessToken, "test_bot_token")
+			},
+			expect:   "test_bot_token",
+			expectOk: true,
+		},
+		{
+			name:     "test missing bot token",
+			setEnv:   func(t *testing.T) {},
+			expect:   "",
+			expectOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment variables
+			tt.setEnv(t)
+
+			result, ok := getSlackBotToken()
+			assert.Equal(t, tt.expect, result)
+			assert.Equal(t, tt.expectOk, ok)
+		})
+	}
+}


### PR DESCRIPTION
Following Kubernetes security best practice (https://www.tenable.com/audits/items/CIS_Kubernetes_v1.6.1_Level_2_Master.audit:98de3da69271994afb6211cf86ae4c6b), try to get Slack token from file first, only when the file name is not set, fall back to load token from environment variable directly. Also added unit tests and updated doc. 

Closes #71.