### PR TITLE
Light Pending phase refactor help with future work to deal with problem nodes

### DIFF
--- a/pkg/cloudprovider/aws/fake/fake.go
+++ b/pkg/cloudprovider/aws/fake/fake.go
@@ -111,6 +111,16 @@ func (m *Autoscaling) DescribeAutoScalingGroups(input *autoscaling.DescribeAutoS
 	}, nil
 }
 
+func (m *Autoscaling) AttachInstances(input *autoscaling.AttachInstancesInput) (*autoscaling.AttachInstancesOutput, error) {
+	for _, instanceId := range input.InstanceIds {
+		if instance, exists := m.Instances[*instanceId]; exists {
+			instance.AutoscalingGroupName = *input.AutoScalingGroupName
+		}
+	}
+
+	return &autoscaling.AttachInstancesOutput{}, nil
+}
+
 // *************** EC2 *************** //
 
 func (m *Ec2) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {

--- a/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
@@ -405,10 +405,11 @@ func TestPendingReattachedCloudProviderNode(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	// "re-attach" one instance from the asg
+	// "re-attach" the instance to the asg
 	fakeTransitioner.cloudProviderInstances[0].Nodegroup = "ng-1"
 
-	// This time should transition to the healing phase
+	// This time should transition to the healing phase even though the state
+	// is correct because the timeout check happens first
 	_, err = fakeTransitioner.Run()
 	assert.Error(t, err)
 	assert.Equal(t, v1.CycleNodeRequestHealing, cnr.Status.Phase)

--- a/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
@@ -398,10 +398,12 @@ func TestPendingReattachedCloudProviderNode(t *testing.T) {
 		Time: time.Now().Add(-nodeEquilibriumWaitLimit - time.Second),
 	}
 
-	fakeTransitioner.Autoscaling.AttachInstances(&autoscaling.AttachInstancesInput{
+	_, err = fakeTransitioner.Autoscaling.AttachInstances(&autoscaling.AttachInstancesInput{
 		AutoScalingGroupName: aws.String("ng-1"),
 		InstanceIds:          aws.StringSlice([]string{nodegroup[0].InstanceID}),
 	})
+
+	assert.NoError(t, err)
 
 	// "re-attach" one instance from the asg
 	fakeTransitioner.cloudProviderInstances[0].Nodegroup = "ng-1"

--- a/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
@@ -295,7 +295,7 @@ func TestPendingNoKubeNodes(t *testing.T) {
 
 // Test to ensure that Cyclops will not proceed if there is node detached from
 // the nodegroup on the cloud provider. It should try to wait for the issue to
-// resolve transition to the Healing phase if it doesn't.
+// resolve to transition to the Healing phase if it doesn't.
 func TestPendingDetachedCloudProviderNode(t *testing.T) {
 	nodegroup, err := mock.NewNodegroup("ng-1", 2)
 	if err != nil {
@@ -349,10 +349,78 @@ func TestPendingDetachedCloudProviderNode(t *testing.T) {
 }
 
 // Test to ensure that Cyclops will not proceed if there is node detached from
+// the nodegroup on the cloud provider. It should try to wait for the issue to
+// resolve and transition to Initialised when it does before reaching the
+// timeout period.
+func TestPendingReattachedCloudProviderNode(t *testing.T) {
+	nodegroup, err := mock.NewNodegroup("ng-1", 2)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+
+	// "detach" one instance from the asg
+	nodegroup[0].Nodegroup = ""
+
+	cnr := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cnr-1",
+			Namespace: "kube-system",
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupsList: []string{"ng-1"},
+			CycleSettings: v1.CycleSettings{
+				Concurrency: 1,
+				Method:      v1.CycleNodeRequestMethodDrain,
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"customer": "kitt",
+				},
+			},
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase: v1.CycleNodeRequestPending,
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr,
+		WithKubeNodes(nodegroup),
+		WithCloudProviderInstances(nodegroup),
+	)
+
+	// Should requeue while it tries to wait
+	_, err = fakeTransitioner.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, v1.CycleNodeRequestPending, cnr.Status.Phase)
+
+	// Simulate waiting for 1s less than the wait limit
+	cnr.Status.EquilibriumWaitStarted = &metav1.Time{
+		Time: time.Now().Add(-nodeEquilibriumWaitLimit + time.Second),
+	}
+
+	_, err = fakeTransitioner.Autoscaling.AttachInstances(&autoscaling.AttachInstancesInput{
+		AutoScalingGroupName: aws.String("ng-1"),
+		InstanceIds:          aws.StringSlice([]string{nodegroup[0].InstanceID}),
+	})
+
+	assert.NoError(t, err)
+
+	// "re-attach" the instance to the asg
+	fakeTransitioner.cloudProviderInstances[0].Nodegroup = "ng-1"
+
+	// The CNR should transition to the Initialised phase because the state of
+	// the nodes is now correct and this happened within the timeout period.
+	_, err = fakeTransitioner.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, v1.CycleNodeRequestInitialised, cnr.Status.Phase)
+	assert.Len(t, cnr.Status.NodesToTerminate, 2)
+}
+
+// Test to ensure that Cyclops will not proceed if there is node detached from
 // the nodegroup on the cloud provider. It should wait and especially should not
 // succeed if the instance is re-attached by the final requeuing of the Pending
 // phase which would occur after the timeout period.
-func TestPendingReattachedCloudProviderNode(t *testing.T) {
+func TestPendingReattachedCloudProviderNodeTooLate(t *testing.T) {
 	nodegroup, err := mock.NewNodegroup("ng-1", 2)
 	if err != nil {
 		assert.NoError(t, err)

--- a/pkg/controller/cyclenoderequest/transitioner/util_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util_test.go
@@ -135,7 +135,7 @@ func TestFindOffendingNodes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			nodesNotInCPNodeGroup, nodesNotInKube := findOffendingNodes(test.knodes, test.cnodes)
+			nodesNotInCPNodeGroup, nodesNotInKube := findProblemNodes(test.knodes, test.cnodes)
 			assert.Equal(t, true, reflect.DeepEqual(test.expectNotInCPNodeGroup, nodesNotInCPNodeGroup))
 			assert.Equal(t, true, reflect.DeepEqual(test.expectNotInKube, nodesNotInKube))
 		})


### PR DESCRIPTION
Small PR to refactor the Pending phase to set the stage for dealing with the different kinds of problem nodes that can occur when collecting the nodes in the Pending phase. This PR does makes minimal changes to the behavior or cyclops. All tests pass as before.

Moving the check for the equilibrium timeout to the start of the Pending phase. This feels like more appropriate placement as it should run before any attempts that are made to fix the state of the nodes in kube and the cloud provider. If it reaches the time to time out then it should fail, not have another attempt at fixing things since the timeout period is long enough at 5 minutes.