### PR TITLE
Fix node state in the Pending phase before cycling

### DIFF
--- a/docs/cycling/README.md
+++ b/docs/cycling/README.md
@@ -28,8 +28,6 @@ The CycleNodeRequest CRD handles a request to cycle nodes belonging to a specifi
 
 2. Validate the CycleNodeRequest object's parameters, and if valid, transition the object to **Pending**.
 
-3. In the **Pending** phase, store the nodes that will need to be cycled so we can keep track of them. Describe the node group in the cloud provider and check it to ensure it matches the nodes in Kubernetes. It will wait for a brief period for the nodes to match, in case the cluster has just scaled up or down. Transition the object to **Initialised**.
-
 3. In the **Pending** phase, store the nodes that will need to be cycled so we can keep track of them. Describe the node group in the cloud provider and check it to ensure it matches the nodes in Kubernetes. It will wait for a brief period and proactively clean up any orphaned node objects, re-attach any instances that have been detached from the cloud provider node group, and then wait for the nodes to match in case the cluster has just scaled up or down. Transition the object to **Initialised**.
 
 4. In the **Initialised** phase, detach a number of nodes (governed by the concurrency of the CycleNodeRequest) from the node group. This will trigger the cloud provider to add replacement nodes for each. Transition the object to **ScalingUp**. If there are no more nodes to cycle then transition to **Successful**.

--- a/docs/cycling/README.md
+++ b/docs/cycling/README.md
@@ -30,6 +30,8 @@ The CycleNodeRequest CRD handles a request to cycle nodes belonging to a specifi
 
 3. In the **Pending** phase, store the nodes that will need to be cycled so we can keep track of them. Describe the node group in the cloud provider and check it to ensure it matches the nodes in Kubernetes. It will wait for a brief period for the nodes to match, in case the cluster has just scaled up or down. Transition the object to **Initialised**.
 
+3. In the **Pending** phase, store the nodes that will need to be cycled so we can keep track of them. Describe the node group in the cloud provider and check it to ensure it matches the nodes in Kubernetes. It will wait for a brief period and proactively clean up any orphaned node objects, re-attach any instances that have been detached from the cloud provider node group, and then wait for the nodes to match in case the cluster has just scaled up or down. Transition the object to **Initialised**.
+
 4. In the **Initialised** phase, detach a number of nodes (governed by the concurrency of the CycleNodeRequest) from the node group. This will trigger the cloud provider to add replacement nodes for each. Transition the object to **ScalingUp**. If there are no more nodes to cycle then transition to **Successful**.
 
 5. In the **ScalingUp** phase, wait for the cloud provider to bring up the new nodes and then wait for the new nodes to be **Ready** in the Kubernetes API. Wait for the configured health checks on the node succeed. Transition the object to **CordoningNode**.

--- a/pkg/cloudprovider/interface.go
+++ b/pkg/cloudprovider/interface.go
@@ -3,7 +3,7 @@ package cloudprovider
 // CloudProvider provides an interface to interact with a cloud provider, e.g. AWS, GCP etc.
 type CloudProvider interface {
 	Name() string
-	InstancesExist([]string) ([]string, error)
+	InstancesExist([]string) (map[string]interface{}, error)
 	GetNodeGroups([]string) (NodeGroups, error)
 	TerminateInstance(string) error
 }

--- a/pkg/controller/cyclenoderequest/transitioner/test_helpers.go
+++ b/pkg/controller/cyclenoderequest/transitioner/test_helpers.go
@@ -12,13 +12,13 @@ type Option func(t *Transitioner)
 
 func WithCloudProviderInstances(nodes []*mock.Node) Option {
 	return func(t *Transitioner) {
-		t.cloudProviderInstances = append(t.cloudProviderInstances, nodes...)
+		t.CloudProviderInstances = append(t.CloudProviderInstances, nodes...)
 	}
 }
 
 func WithKubeNodes(nodes []*mock.Node) Option {
 	return func(t *Transitioner) {
-		t.kubeNodes = append(t.kubeNodes, nodes...)
+		t.KubeNodes = append(t.KubeNodes, nodes...)
 	}
 }
 
@@ -28,23 +28,23 @@ type Transitioner struct {
 	*CycleNodeRequestTransitioner
 	*mock.Client
 
-	cloudProviderInstances []*mock.Node
-	kubeNodes              []*mock.Node
+	CloudProviderInstances []*mock.Node
+	KubeNodes              []*mock.Node
 }
 
 func NewFakeTransitioner(cnr *v1.CycleNodeRequest, opts ...Option) *Transitioner {
 	t := &Transitioner{
 		// By default there are no nodes and each test will
 		// override these as needed
-		cloudProviderInstances: make([]*mock.Node, 0),
-		kubeNodes:              make([]*mock.Node, 0),
+		CloudProviderInstances: make([]*mock.Node, 0),
+		KubeNodes:              make([]*mock.Node, 0),
 	}
 
 	for _, opt := range opts {
 		opt(t)
 	}
 
-	t.Client = mock.NewClient(t.kubeNodes, t.cloudProviderInstances, cnr)
+	t.Client = mock.NewClient(t.KubeNodes, t.CloudProviderInstances, cnr)
 
 	rm := &controller.ResourceManager{
 		Client:        t.K8sClient,

--- a/pkg/controller/cyclenoderequest/transitioner/transitions_initialized_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions_initialized_test.go
@@ -1,0 +1,94 @@
+package transitioner
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
+	"github.com/atlassian-labs/cyclops/pkg/mock"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Base case of the Initialized phase. Start cycling by detaching an instance
+// and adding the cycling finalizer and annotation to it.
+func TestInitializedSimpleCase(t *testing.T) {
+	nodegroup, err := mock.NewNodegroup("ng-1", 1)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+
+	// CNR straight after being transitioned from Pending
+	cnr := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cnr-1",
+			Namespace: "kube-system",
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupsList: []string{"ng-1"},
+			CycleSettings: v1.CycleSettings{
+				Concurrency: 1,
+				Method:      v1.CycleNodeRequestMethodDrain,
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"customer": "kitt",
+				},
+			},
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase: v1.CycleNodeRequestInitialised,
+			NodesToTerminate: []v1.CycleNodeRequestNode{
+				{
+					Name:          nodegroup[0].Name,
+					NodeGroupName: nodegroup[0].Nodegroup,
+				},
+			},
+			NodesAvailable: []v1.CycleNodeRequestNode{
+				{
+					Name:          nodegroup[0].Name,
+					NodeGroupName: nodegroup[0].Nodegroup,
+				},
+			},
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr,
+		WithKubeNodes(nodegroup),
+		WithCloudProviderInstances(nodegroup),
+	)
+
+	// Populate the provider id because it gets generated in NewFakeTransitioner
+	cnr.Status.NodesToTerminate[0].ProviderID = fakeTransitioner.KubeNodes[0].ProviderID
+	cnr.Status.NodesAvailable[0].ProviderID = fakeTransitioner.KubeNodes[0].ProviderID
+
+	// Execute the Initialized phase
+	_, err = fakeTransitioner.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, v1.CycleNodeRequestScalingUp, cnr.Status.Phase)
+	assert.Len(t, cnr.Status.NodesToTerminate, 1)
+	assert.Len(t, cnr.Status.NodesAvailable, 0)
+
+	// Ensure that the instance is detached from the ASG
+	output, err := fakeTransitioner.Autoscaling.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	assert.NoError(t, err)
+
+	// Quirk of the mocking, it constructs the list of ASGs from the list of
+	// nodes so 0 ASGs here means that the node has been detached
+	assert.Equal(t, 0, len(output.AutoScalingGroups))
+
+	// Ensure the node has the cycling finalizer applied to it
+	node, err := fakeTransitioner.rm.RawClient.CoreV1().Nodes().Get(
+		context.TODO(), nodegroup[0].Name, metav1.GetOptions{},
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, node.Finalizers, 1)
+
+	// Ensure the node has the cycling annotation applied to it
+	nodegroupName, err := fakeTransitioner.rm.GetNodegroupFromNodeAnnotation(nodegroup[0].Name)
+	assert.NoError(t, err)
+	assert.Equal(t, "ng-1", nodegroupName)
+}

--- a/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
@@ -524,9 +524,11 @@ func TestPendingTimeoutReached(t *testing.T) {
 	assert.Equal(t, v1.CycleNodeRequestPending, cnr.Status.Phase)
 
 	// Keep the node detached
-	fakeTransitioner.Autoscaling.DetachInstances(&autoscaling.DetachInstancesInput{
+	_, err = fakeTransitioner.Autoscaling.DetachInstances(&autoscaling.DetachInstancesInput{
 		InstanceIds: aws.StringSlice([]string{nodegroup[0].InstanceID}),
 	})
+
+	assert.NoError(t, err)
 
 	output, err = fakeTransitioner.Autoscaling.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 	assert.NoError(t, err)

--- a/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/atlassian-labs/cyclops/pkg/mock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -293,10 +294,65 @@ func TestPendingNoKubeNodes(t *testing.T) {
 	assert.Equal(t, v1.CycleNodeRequestHealing, cnr.Status.Phase)
 }
 
-// Test to ensure that Cyclops will not proceed if there is node detached from
-// the nodegroup on the cloud provider. It should try to wait for the issue to
-// resolve to transition to the Healing phase if it doesn't.
-func TestPendingDetachedCloudProviderNode(t *testing.T) {
+// Test to ensure that node objects that exist in the cluster without a matching
+// instance in the cloud provider are cleaned up and then cycling can proceed
+// as normal.
+func TestPendingOrphanedKubeNodes(t *testing.T) {
+	nodegroup, err := mock.NewNodegroup("ng-1", 2)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+
+	cnr := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cnr-1",
+			Namespace: "kube-system",
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupsList: []string{"ng-1"},
+			CycleSettings: v1.CycleSettings{
+				Concurrency: 1,
+				Method:      v1.CycleNodeRequestMethodDrain,
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"customer": "kitt",
+				},
+			},
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase: v1.CycleNodeRequestPending,
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr,
+		WithKubeNodes(nodegroup),
+		WithCloudProviderInstances(nodegroup[:1]),
+	)
+
+	// The first run of the transitioner should go through and try to fix the
+	// inconsistency between kube and the cloud provider and will requeue the
+	// Pending phase to check again.
+	_, err = fakeTransitioner.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, v1.CycleNodeRequestPending, cnr.Status.Phase)
+
+	// The existing instance in the cloud provider should still be the only one
+	output, err := fakeTransitioner.Ec2.DescribeInstances(&ec2.DescribeInstancesInput{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(output.Reservations[0].Instances))
+
+	// After running again, the orphaned kube node is observed to have been
+	// removed and the CNR was transitioned to the Initialized phase
+	_, err = fakeTransitioner.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, v1.CycleNodeRequestInitialised, cnr.Status.Phase)
+	assert.Len(t, cnr.Status.NodesToTerminate, 1)
+}
+
+// Test to ensure that an instance detached from one of the CNR named cloud
+// provider nodegroups is re-attached before proceeding with cycling.
+func TestPendingDetachedCloudProviderInstance(t *testing.T) {
 	nodegroup, err := mock.NewNodegroup("ng-1", 2)
 	if err != nil {
 		assert.NoError(t, err)
@@ -332,10 +388,150 @@ func TestPendingDetachedCloudProviderNode(t *testing.T) {
 		WithCloudProviderInstances(nodegroup),
 	)
 
-	// Should requeue while it tries to wait
+	// Ensure there's only one instance in the ASG
+	output, err := fakeTransitioner.Autoscaling.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(output.AutoScalingGroups))
+	assert.Equal(t, 1, len(output.AutoScalingGroups[0].Instances))
+
+	// The first run of the transitioner should go through and try to fix the
+	// inconsistency between kube and the cloud provider and will requeue the
+	// Pending phase to check again.
 	_, err = fakeTransitioner.Run()
 	assert.NoError(t, err)
 	assert.Equal(t, v1.CycleNodeRequestPending, cnr.Status.Phase)
+
+	// Ensure both instance are now in the ASG
+	output, err = fakeTransitioner.Autoscaling.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(output.AutoScalingGroups))
+	assert.Equal(t, 2, len(output.AutoScalingGroups[0].Instances))
+
+	// This time should transition to the initialized phase
+	_, err = fakeTransitioner.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, v1.CycleNodeRequestInitialised, cnr.Status.Phase)
+	assert.Len(t, cnr.Status.NodesToTerminate, 2)
+}
+
+// Test to ensure that a detached instance with a matching kube object that does
+// not have the cycling annotation to identify it's original cloud provider
+// nodegroup should cause the cycling to fail immediately since this is a case
+// that cannot be fixed automatically.
+func TestPendingDetachedCloudProviderInstanceNoAnnotation(t *testing.T) {
+	nodegroup, err := mock.NewNodegroup("ng-1", 2)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+
+	// "detach" one instance from the asg and simulate the node not having
+	// the annotation
+	nodegroup[0].Nodegroup = ""
+	nodegroup[0].AnnotationKey = ""
+	nodegroup[0].AnnotationValue = ""
+
+	cnr := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cnr-1",
+			Namespace: "kube-system",
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupsList: []string{"ng-1"},
+			CycleSettings: v1.CycleSettings{
+				Concurrency: 1,
+				Method:      v1.CycleNodeRequestMethodDrain,
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"customer": "kitt",
+				},
+			},
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase: v1.CycleNodeRequestPending,
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr,
+		WithKubeNodes(nodegroup),
+		WithCloudProviderInstances(nodegroup),
+	)
+
+	// Ensure there's only one instance in the ASG
+	output, err := fakeTransitioner.Autoscaling.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(output.AutoScalingGroups))
+	assert.Equal(t, 1, len(output.AutoScalingGroups[0].Instances))
+
+	// The first run of the transitioner should go through and try to fix the
+	// inconsistency between kube and the cloud provider. However, the node
+	// object for the detached instance does not have the nodegroup annotation
+	// so it cannot be re-attached. The CNR should fail because this cannot be
+	// fixed.
+	_, err = fakeTransitioner.Run()
+	assert.Error(t, err)
+	assert.Equal(t, v1.CycleNodeRequestHealing, cnr.Status.Phase)
+}
+
+// Test to ensure that if the instance state cannot be fixed during the
+// equilibrium timeout period, then cycling is failed.
+func TestPendingTimeoutReached(t *testing.T) {
+	nodegroup, err := mock.NewNodegroup("ng-1", 2)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+
+	// "detach" one instance from the asg
+	nodegroup[0].Nodegroup = ""
+
+	cnr := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cnr-1",
+			Namespace: "kube-system",
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupsList: []string{"ng-1"},
+			CycleSettings: v1.CycleSettings{
+				Concurrency: 1,
+				Method:      v1.CycleNodeRequestMethodDrain,
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"customer": "kitt",
+				},
+			},
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase: v1.CycleNodeRequestPending,
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr,
+		WithKubeNodes(nodegroup),
+		WithCloudProviderInstances(nodegroup),
+	)
+
+	output, err := fakeTransitioner.Autoscaling.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(output.AutoScalingGroups))
+	assert.Equal(t, 1, len(output.AutoScalingGroups[0].Instances))
+
+	// The first run of the transitioner should go through and try to fix the
+	// inconsistency between kube and the cloud provider and will requeue the
+	// Pending phase to check again.
+	_, err = fakeTransitioner.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, v1.CycleNodeRequestPending, cnr.Status.Phase)
+
+	// Keep the node detached
+	fakeTransitioner.Autoscaling.DetachInstances(&autoscaling.DetachInstancesInput{
+		InstanceIds: aws.StringSlice([]string{nodegroup[0].InstanceID}),
+	})
+
+	output, err = fakeTransitioner.Autoscaling.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(output.AutoScalingGroups))
+	assert.Equal(t, 1, len(output.AutoScalingGroups[0].Instances))
 
 	// Simulate waiting for 1s more than the wait limit
 	cnr.Status.EquilibriumWaitStarted = &metav1.Time{
@@ -346,74 +542,6 @@ func TestPendingDetachedCloudProviderNode(t *testing.T) {
 	_, err = fakeTransitioner.Run()
 	assert.Error(t, err)
 	assert.Equal(t, v1.CycleNodeRequestHealing, cnr.Status.Phase)
-}
-
-// Test to ensure that Cyclops will not proceed if there is node detached from
-// the nodegroup on the cloud provider. It should try to wait for the issue to
-// resolve and transition to Initialised when it does before reaching the
-// timeout period.
-func TestPendingReattachedCloudProviderNode(t *testing.T) {
-	nodegroup, err := mock.NewNodegroup("ng-1", 2)
-	if err != nil {
-		assert.NoError(t, err)
-	}
-
-	// "detach" one instance from the asg
-	nodegroup[0].Nodegroup = ""
-
-	cnr := &v1.CycleNodeRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cnr-1",
-			Namespace: "kube-system",
-		},
-		Spec: v1.CycleNodeRequestSpec{
-			NodeGroupsList: []string{"ng-1"},
-			CycleSettings: v1.CycleSettings{
-				Concurrency: 1,
-				Method:      v1.CycleNodeRequestMethodDrain,
-			},
-			Selector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"customer": "kitt",
-				},
-			},
-		},
-		Status: v1.CycleNodeRequestStatus{
-			Phase: v1.CycleNodeRequestPending,
-		},
-	}
-
-	fakeTransitioner := NewFakeTransitioner(cnr,
-		WithKubeNodes(nodegroup),
-		WithCloudProviderInstances(nodegroup),
-	)
-
-	// Should requeue while it tries to wait
-	_, err = fakeTransitioner.Run()
-	assert.NoError(t, err)
-	assert.Equal(t, v1.CycleNodeRequestPending, cnr.Status.Phase)
-
-	// Simulate waiting for 1s less than the wait limit
-	cnr.Status.EquilibriumWaitStarted = &metav1.Time{
-		Time: time.Now().Add(-nodeEquilibriumWaitLimit + time.Second),
-	}
-
-	_, err = fakeTransitioner.Autoscaling.AttachInstances(&autoscaling.AttachInstancesInput{
-		AutoScalingGroupName: aws.String("ng-1"),
-		InstanceIds:          aws.StringSlice([]string{nodegroup[0].InstanceID}),
-	})
-
-	assert.NoError(t, err)
-
-	// "re-attach" the instance to the asg
-	fakeTransitioner.cloudProviderInstances[0].Nodegroup = "ng-1"
-
-	// The CNR should transition to the Initialised phase because the state of
-	// the nodes is now correct and this happened within the timeout period.
-	_, err = fakeTransitioner.Run()
-	assert.NoError(t, err)
-	assert.Equal(t, v1.CycleNodeRequestInitialised, cnr.Status.Phase)
-	assert.Len(t, cnr.Status.NodesToTerminate, 2)
 }
 
 // Test to ensure that Cyclops will not proceed if there is node detached from
@@ -465,16 +593,6 @@ func TestPendingReattachedCloudProviderNodeTooLate(t *testing.T) {
 	cnr.Status.EquilibriumWaitStarted = &metav1.Time{
 		Time: time.Now().Add(-nodeEquilibriumWaitLimit - time.Second),
 	}
-
-	_, err = fakeTransitioner.Autoscaling.AttachInstances(&autoscaling.AttachInstancesInput{
-		AutoScalingGroupName: aws.String("ng-1"),
-		InstanceIds:          aws.StringSlice([]string{nodegroup[0].InstanceID}),
-	})
-
-	assert.NoError(t, err)
-
-	// "re-attach" the instance to the asg
-	fakeTransitioner.cloudProviderInstances[0].Nodegroup = "ng-1"
 
 	// This time should transition to the healing phase even though the state
 	// is correct because the timeout check happens first

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -3,9 +3,12 @@ package transitioner
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,6 +33,35 @@ func (t *CycleNodeRequestTransitioner) transitionToFailed(err error) (reconcile.
 	}
 
 	return t.transitionToUnsuccessful(v1.CycleNodeRequestFailed, err)
+}
+
+// transitionToUnsuccessful transitions the current cycleNodeRequest to healing/failed
+func (t *CycleNodeRequestTransitioner) transitionToUnsuccessful(phase v1.CycleNodeRequestPhase, err error) (reconcile.Result, error) {
+	t.cycleNodeRequest.Status.Phase = phase
+	// don't try to append message if it's nil
+	if err != nil {
+		if t.cycleNodeRequest.Status.Message != "" {
+			t.cycleNodeRequest.Status.Message += ", "
+		}
+
+		t.cycleNodeRequest.Status.Message += err.Error()
+	}
+
+	// handle conflicts before complaining
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return t.rm.UpdateObject(t.cycleNodeRequest)
+	}); err != nil {
+		t.rm.Logger.Error(err, "unable to update cycleNodeRequest")
+	}
+
+	// Notify that the cycling has transitioned phase
+	if t.rm.Notifier != nil {
+		if err := t.rm.Notifier.PhaseTransitioned(t.cycleNodeRequest); err != nil {
+			t.rm.Logger.Error(err, "Unable to post message to messaging provider", "phase", t.cycleNodeRequest.Status.Phase)
+		}
+	}
+
+	return reconcile.Result{}, err
 }
 
 // transitionToSuccessful transitions the current cycleNodeRequest to successful
@@ -74,12 +106,15 @@ func (t *CycleNodeRequestTransitioner) equilibriumWaitTimedOut() (bool, error) {
 	// If the timer isn't initialised, initialise it and save it to the object
 	if t.cycleNodeRequest.Status.EquilibriumWaitStarted.IsZero() {
 		t.rm.Logger.Info("started equilibrium wait")
+
 		currentTime := metav1.Now()
 		t.cycleNodeRequest.Status.EquilibriumWaitStarted = &currentTime
+
 		if err := t.rm.UpdateObject(t.cycleNodeRequest); err != nil {
 			return false, err
 		}
 	}
+
 	return time.Now().After(t.cycleNodeRequest.Status.EquilibriumWaitStarted.Time.Add(nodeEquilibriumWaitLimit)), nil
 }
 
@@ -295,31 +330,202 @@ func findProblemNodes(kubeNodes map[string]corev1.Node, nodeGroupInstances map[s
 	return problemKubeNodes, problemNodegroupInstances
 }
 
-// transitionToUnsuccessful transitions the current cycleNodeRequest to healing/failed
-func (t *CycleNodeRequestTransitioner) transitionToUnsuccessful(phase v1.CycleNodeRequestPhase, err error) (reconcile.Result, error) {
-	t.cycleNodeRequest.Status.Phase = phase
-	// don't try to append message if it's nil
+// reattachAnyDetachedInstances re-attaches any instances which are detached from the cloud
+// provider nodegroups defined in the CNR using the cycling annotation to identify which one.
+func (t *CycleNodeRequestTransitioner) reattachAnyDetachedInstances(nodesNotInCloudProviderNodegroup map[string]corev1.Node) error {
+	var nodeProviderIDs []string
+
+	if len(nodesNotInCloudProviderNodegroup) == 0 {
+		return nil
+	}
+
+	for _, node := range nodesNotInCloudProviderNodegroup {
+		nodeProviderIDs = append(nodeProviderIDs, node.Spec.ProviderID)
+	}
+
+	existingProviderIDs, err := t.rm.CloudProvider.InstancesExist(nodeProviderIDs)
 	if err != nil {
-		if t.cycleNodeRequest.Status.Message != "" {
-			t.cycleNodeRequest.Status.Message += ", "
+		return errors.Wrap(err, "failed to check instances that exist from cloud provider")
+	}
+
+	nodeGroups, err := t.rm.CloudProvider.GetNodeGroups(t.cycleNodeRequest.GetNodeGroupNames())
+	if err != nil {
+		return err
+	}
+
+	for providerID, node := range nodesNotInCloudProviderNodegroup {
+		_, instanceExists := existingProviderIDs[providerID]
+
+		if !instanceExists {
+			continue
 		}
 
-		t.cycleNodeRequest.Status.Message += err.Error()
-	}
+		// The kube node is now established to be backed by an instance in the cloud provider
+		// that is detached from it's nodegroup. Use the nodegroup annotation from the kube
+		// node set as part of a previous cycle to re-attach it.
+		nodegroupName, err := t.rm.GetNodegroupFromNodeAnnotation(node.Name)
 
-	// handle conflicts before complaining
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return t.rm.UpdateObject(t.cycleNodeRequest)
-	}); err != nil {
-		t.rm.Logger.Error(err, "unable to update cycleNodeRequest")
-	}
+		// If there is an error because the kube node no longer exists then simply skip any
+		// more action on the node and go to the next one. This case can be fixed in the next
+		// run of the Pending phase.
+		if apierrors.IsNotFound(err) {
+			continue
+		}
 
-	// Notify that the cycling has transitioned phase
-	if t.rm.Notifier != nil {
-		if err := t.rm.Notifier.PhaseTransitioned(t.cycleNodeRequest); err != nil {
-			t.rm.Logger.Error(err, "Unable to post message to messaging provider", "phase", t.cycleNodeRequest.Status.Phase)
+		// Otherwise error out to end the cycle. This includes if the cycling annotation is
+		// missing since there is no link between the original cloud provider instance and it's
+		// nodegroup so there's no way to re-attach it.
+		if err != nil {
+			return err
+		}
+
+		// AttachInstance does not error out if the instance does not exist so no need to handle
+		// it here. Error out on any error that can't be fixed by repeating the attempts to fix
+		// the instance state.
+		alreadyAttached, err := nodeGroups.AttachInstance(node.Spec.ProviderID, nodegroupName)
+		if err != nil && !alreadyAttached {
+			return err
 		}
 	}
 
-	return reconcile.Result{}, err
+	return nil
+}
+
+// deleteAnyOrphanedKubeNodes filters through the kube nodes without instances in the cloud provider
+// nodegroups which don't have an instance in the cloud provider at all. It removes the cycling
+// finalizer and deletes the node.
+func (t *CycleNodeRequestTransitioner) deleteAnyOrphanedKubeNodes(nodesNotInCloudProviderNodegroup map[string]corev1.Node) error {
+	var nodeProviderIDs []string
+
+	if len(nodesNotInCloudProviderNodegroup) == 0 {
+		return nil
+	}
+
+	for _, node := range nodesNotInCloudProviderNodegroup {
+		nodeProviderIDs = append(nodeProviderIDs, node.Spec.ProviderID)
+	}
+
+	existingProviderIDs, err := t.rm.CloudProvider.InstancesExist(nodeProviderIDs)
+	if err != nil {
+		return errors.Wrap(err, "failed to check instances that exist from cloud provider")
+	}
+
+	// Find all the orphaned kube nodes from the set of nodes without matching instance in the
+	// cloud provider nodegroup.
+	for providerID, node := range nodesNotInCloudProviderNodegroup {
+		_, instanceExists := existingProviderIDs[providerID]
+
+		if instanceExists {
+			continue
+		}
+
+		// The kube node is now established to be orphaned. Check the finalizers on the node
+		// object and ensure that only the Cyclops finalizer exists on it. If another finalizer
+		// exists then it's from another controller and it should not be deleted.
+		containsNonCyclingFinalizer, err := t.rm.NodeContainsNonCyclingFinalizer(node.Name)
+		if err != nil {
+			return errors.Wrap(err,
+				fmt.Sprintf("failed to check if node %s contains a non-cycling finalizer", node.Name),
+			)
+		}
+
+		if containsNonCyclingFinalizer {
+			return fmt.Errorf("can't delete node %s because it contains non-cycling finalizers: %v",
+				node.Name,
+				node.Finalizers,
+			)
+		}
+
+		// The cycling finalizer is the only one on the node so remove it.
+		if err := t.rm.RemoveFinalizerFromNode(node.Name); err != nil {
+			return err
+		}
+
+		// Delete the node to ensure it gets removed from kube. It is possible that the finalizer
+		// was preventing the node object from being deleted and the node is deleted by the time
+		// this delete call is reached. Don't if the node is already deleted since that is desired
+		// effect.
+		if err := t.rm.DeleteNode(node.Name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// errorIfEquilibriumTimeoutReached reduces the footprint of this check in the
+// Pending transition
+func (t *CycleNodeRequestTransitioner) errorIfEquilibriumTimeoutReached() error {
+	timedOut, err := t.equilibriumWaitTimedOut()
+	if err != nil {
+		return err
+	}
+
+	if timedOut {
+		return fmt.Errorf(
+			"node count mismatch, number of kubernetes nodes does not match number of cloud provider instances after %v",
+			nodeEquilibriumWaitLimit,
+		)
+	}
+
+	return nil
+}
+
+// logProblemNodes generates event message describing any issues with the node state prior
+// to cycling.
+func (t *CycleNodeRequestTransitioner) logProblemNodes(nodesNotInCloudProviderNodegroup map[string]corev1.Node, instancesNotInKube map[string]cloudprovider.Instance) {
+	var offendingNodesInfo string
+
+	if len(nodesNotInCloudProviderNodegroup) > 0 {
+		providerIDs := make([]string, 0)
+
+		for providerID := range nodesNotInCloudProviderNodegroup {
+			providerIDs = append(providerIDs,
+				fmt.Sprintf("id %q", providerID),
+			)
+		}
+
+		offendingNodesInfo += "nodes not in node group: "
+		offendingNodesInfo += strings.Join(providerIDs, ",")
+	}
+
+	if len(instancesNotInKube) > 0 {
+		if offendingNodesInfo != "" {
+			offendingNodesInfo += ";"
+		}
+
+		providerIDs := make([]string, 0)
+
+		for providerID, node := range instancesNotInKube {
+			providerIDs = append(providerIDs,
+				fmt.Sprintf("id %q in %q", providerID, node.NodeGroupName()),
+			)
+		}
+
+		offendingNodesInfo += "nodes not inside cluster: "
+		offendingNodesInfo += strings.Join(providerIDs, ",")
+	}
+
+	t.rm.LogEvent(t.cycleNodeRequest, "NodeStateInvalid",
+		"instances missing: %v, kube nodes missing: %v. %v",
+		len(nodesNotInCloudProviderNodegroup), len(instancesNotInKube), offendingNodesInfo,
+	)
+}
+
+// validateInstanceState performs final validation on the nodegroup to ensure
+// that all the cloud provider instances are ready in the nodegroup.
+func (t *CycleNodeRequestTransitioner) validateInstanceState(validNodeGroupInstances map[string]cloudprovider.Instance) (bool, error) {
+	nodeGroups, err := t.rm.CloudProvider.GetNodeGroups(
+		t.cycleNodeRequest.GetNodeGroupNames(),
+	)
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(nodeGroups.ReadyInstances()) == len(validNodeGroupInstances) {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -61,6 +61,19 @@ func AddLabelToNode(nodeName string, labelName string, labelValue string, client
 	return PatchNode(nodeName, patches, client)
 }
 
+// AddAnnotationToNode performs a patch operation on a node to add an annotation to the node
+func AddAnnotationToNode(nodeName string, annotationName string, annotationValue string, client kubernetes.Interface) error {
+	patches := []Patch{
+		{
+			Op: "add",
+			// json patch spec maps "~1" to "/" as an escape sequence, so we do the translation here...
+			Path:  fmt.Sprintf("/metadata/annotations/%s", strings.Replace(annotationName, "/", "~1", -1)),
+			Value: annotationValue,
+		},
+	}
+	return PatchNode(nodeName, patches, client)
+}
+
 // AddFinalizerToNode updates a node to add a finalizer to it
 func AddFinalizerToNode(node *v1.Node, finalizerName string, client kubernetes.Interface) error {
 	controllerutil.AddFinalizer(node, finalizerName)

--- a/pkg/mock/client.go
+++ b/pkg/mock/client.go
@@ -26,12 +26,15 @@ import (
 
 type Node struct {
 	Name       string
-	LabelKey   string
-	LabelValue string
 	Creation   time.Time
 	Tainted    bool
 	Nodegroup  string
 	InstanceID string
+
+	LabelKey        string
+	LabelValue      string
+	AnnotationKey   string
+	AnnotationValue string
 
 	NodeReady corev1.ConditionStatus
 
@@ -150,6 +153,9 @@ func buildKubeNode(node *Node) *corev1.Node {
 			SelfLink: fmt.Sprintf("/api/v1/nodes/%s", node.Name),
 			Labels: map[string]string{
 				node.LabelKey: node.LabelValue,
+			},
+			Annotations: map[string]string{
+				node.AnnotationKey: node.AnnotationValue,
 			},
 			CreationTimestamp: metav1.NewTime(node.Creation),
 		},

--- a/pkg/mock/test_helpers.go
+++ b/pkg/mock/test_helpers.go
@@ -22,7 +22,7 @@ func GenerateRandomInstanceId() (string, error) {
 	return "i-" + hexString, nil
 }
 
-func NewNodegroup(name string, num int) ([]*Node, error) {
+func NewNodegroup(nodegroupName string, num int) ([]*Node, error) {
 	nodes := make([]*Node, 0)
 
 	for i := 0; i < num; i++ {
@@ -32,13 +32,15 @@ func NewNodegroup(name string, num int) ([]*Node, error) {
 		}
 
 		node := &Node{
-			Name:               fmt.Sprintf("%s-node-%d", name, i),
+			Name:               fmt.Sprintf("%s-node-%d", nodegroupName, i),
 			LabelKey:           "customer",
 			LabelValue:         "kitt",
+			AnnotationKey:      "cyclops.atlassian.com/nodegroup",
+			AnnotationValue:    nodegroupName,
 			Creation:           time.Now(),
 			Tainted:            false,
 			NodeReady:          corev1.ConditionTrue,
-			Nodegroup:          name,
+			Nodegroup:          nodegroupName,
 			InstanceID:         instanceID,
 			CloudProviderState: "running",
 		}


### PR DESCRIPTION
Updates to the Pending phase:
- Finding all nodes rather than just `Ready` nodes to get an accurate state of the nodes/instances prior to cycling
- Now deleting any node objects in kube that do not have a matching instance in AWS
- Now re-attaching any instances that were detached from the ASG, likely due to an issue in a previous cycle.
- Now when checking if a node has a matching instance in AWS, no longer counting instances that are terminated which would still show up in the list.