### PR TITLE
Add a max failed CNRs threshold to Nodegroups

### DIFF
--- a/deploy/crds/atlassian.com_nodegroups_crd.yaml
+++ b/deploy/crds/atlassian.com_nodegroups_crd.yaml
@@ -149,6 +149,11 @@ spec:
                   - waitPeriod
                   type: object
                 type: array
+              maxFailedCycleNodeRequests:
+                description: MaxFailedCycleNodeRequests defines the maximum number
+                  of allowed failed CNRs for a nodegroup before the observer stops
+                  generating them.
+                type: integer
               nodeGroupName:
                 description: NodeGroupName is the name of the node group in the cloud
                   provider that corresponds to this NodeGroup resource.

--- a/pkg/apis/atlassian/v1/common.go
+++ b/pkg/apis/atlassian/v1/common.go
@@ -31,3 +31,23 @@ func buildNodeGroupNames(nodeGroupsList []string, nodeGroupName string) []string
 
 	return nodeGroups
 }
+
+// sameNodeGroups compares two lists of nodegroup names and check they are the
+// same. Ordering does not affect equality.
+func sameNodeGroups(groupA, groupB []string) bool {
+	if len(groupA) != len(groupB) {
+		return false
+	}
+
+	groupMap := make(map[string]struct{})
+	for _, group := range groupA {
+		groupMap[group] = struct{}{}
+	}
+
+	for _, group := range groupB {
+		if _, ok := groupMap[group]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/apis/atlassian/v1/common_test.go
+++ b/pkg/apis/atlassian/v1/common_test.go
@@ -87,3 +87,44 @@ func TestBuildNodeGroupNames(t *testing.T) {
 		})
 	}
 }
+
+func Test_sameNodeGroups(t *testing.T) {
+	tests := []struct {
+		name   string
+		groupA []string
+		groupB []string
+		expect bool
+	}{
+		{
+			"pass case with same order",
+			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
+			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
+			true,
+		},
+		{
+			"pass case with different order",
+			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
+			[]string{"ingress-us-west-2b", "ingress-us-west-2c", "ingress-us-west-2a"},
+			true,
+		},
+		{
+			"failure case with different length",
+			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
+			[]string{"ingress-us-west-2b", "ingress-us-west-2c"},
+			false,
+		},
+		{
+			"failure case with different items",
+			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
+			[]string{"ingress-us-west-2b", "ingress-us-west-2c", "system"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sameNodeGroups(tt.groupA, tt.groupB)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}

--- a/pkg/apis/atlassian/v1/cyclenoderequest.go
+++ b/pkg/apis/atlassian/v1/cyclenoderequest.go
@@ -15,3 +15,24 @@ func (in *CycleNodeRequest) NodeLabelSelector() (labels.Selector, error) {
 func (in *CycleNodeRequest) GetNodeGroupNames() []string {
 	return buildNodeGroupNames(in.Spec.NodeGroupsList, in.Spec.NodeGroupName)
 }
+
+// IsPartOfNodeGroup returns whether the CycleNodeRequest is part of the
+// provided NodeGroup by comparing the list of named cloud provider nodegroups
+// defined in each one. Ordering does not affect equality.
+func (in *CycleNodeRequest) IsFromNodeGroup(nodegroup NodeGroup) bool {
+	return sameNodeGroups(
+		buildNodeGroupNames(in.Spec.NodeGroupsList, in.Spec.NodeGroupName),
+		nodegroup.GetNodeGroupNames(),
+	)
+}
+
+// IsFromSameNodeGroup returns whether the CycleNodeRequest is part of the
+// same Nodegroup provided as the provided CycleNodeRequest by comparing the
+// list of named cloud provider nodegroups defined in each one. Ordering does
+// not affect equality.
+func (in *CycleNodeRequest) IsFromSameNodeGroup(cnr CycleNodeRequest) bool {
+	return sameNodeGroups(
+		buildNodeGroupNames(in.Spec.NodeGroupsList, in.Spec.NodeGroupName),
+		cnr.GetNodeGroupNames(),
+	)
+}

--- a/pkg/apis/atlassian/v1/nodegroup_types.go
+++ b/pkg/apis/atlassian/v1/nodegroup_types.go
@@ -19,6 +19,10 @@ type NodeGroupSpec struct {
 	// CycleSettings stores the settings to use for cycling the nodes.
 	CycleSettings CycleSettings `json:"cycleSettings"`
 
+	// MaxFailedCycleNodeRequests defines the maximum number of allowed failed CNRs for a nodegroup before the observer
+	// stops generating them.
+	MaxFailedCycleNodeRequests uint `json:"maxFailedCycleNodeRequests,omitempty"`
+
 	// ValidationOptions stores the settings to use for validating state of nodegroups
 	// in kube and the cloud provider for cycling the nodes.
 	ValidationOptions ValidationOptions `json:"validationOptions,omitempty"`

--- a/pkg/controller/cyclenoderequest/transitioner/test_helpers.go
+++ b/pkg/controller/cyclenoderequest/transitioner/test_helpers.go
@@ -26,7 +26,7 @@ func WithKubeNodes(nodes []*mock.Node) Option {
 
 func WithExtraKubeObject(extraKubeObject client.Object) Option {
 	return func(t *Transitioner) {
-		t.extrakubeObjects = append(t.extrakubeObjects, extraKubeObject)
+		t.extraKubeObjects = append(t.extraKubeObjects, extraKubeObject)
 	}
 }
 
@@ -45,7 +45,7 @@ type Transitioner struct {
 	CloudProviderInstances []*mock.Node
 	KubeNodes              []*mock.Node
 
-	extrakubeObjects []client.Object
+	extraKubeObjects []client.Object
 
 	transitionerOptions Options
 }
@@ -56,7 +56,7 @@ func NewFakeTransitioner(cnr *v1.CycleNodeRequest, opts ...Option) *Transitioner
 		// override these as needed
 		CloudProviderInstances: make([]*mock.Node, 0),
 		KubeNodes:              make([]*mock.Node, 0),
-		extrakubeObjects:       []client.Object{cnr},
+		extraKubeObjects:       []client.Object{cnr},
 		transitionerOptions:    Options{},
 	}
 
@@ -65,7 +65,7 @@ func NewFakeTransitioner(cnr *v1.CycleNodeRequest, opts ...Option) *Transitioner
 	}
 
 	t.Client = mock.NewClient(
-		t.KubeNodes, t.CloudProviderInstances, t.extrakubeObjects...,
+		t.KubeNodes, t.CloudProviderInstances, t.extraKubeObjects...,
 	)
 
 	rm := &controller.ResourceManager{

--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -594,8 +594,16 @@ func (t *CycleNodeRequestTransitioner) transitionSuccessful() (reconcile.Result,
 	if err != nil {
 		return t.transitionToHealing(err)
 	}
+
 	if shouldRequeue {
 		return reconcile.Result{Requeue: true, RequeueAfter: transitionDuration}, nil
+	}
+
+	// Delete failed sibling CNRs regardless of whether the CNR for the
+	// transitioner should be deleted. If failed CNRs pile up that will prevent
+	// Cyclops observer from auto-generating new CNRs for a nodegroup.
+	if err := t.deleteFailedSiblingCNRs(); err != nil {
+		return t.transitionToHealing(err)
 	}
 
 	// If deleting CycleNodeRequests is not enabled, stop here
@@ -607,10 +615,11 @@ func (t *CycleNodeRequestTransitioner) transitionSuccessful() (reconcile.Result,
 	// than the time configured to keep them for.
 	if t.cycleNodeRequest.CreationTimestamp.Add(t.options.DeleteCNRExpiry).Before(time.Now()) {
 		t.rm.Logger.Info("Deleting CycleNodeRequest")
-		err := t.rm.Client.Delete(context.TODO(), t.cycleNodeRequest)
-		if err != nil {
+
+		if err := t.rm.Client.Delete(context.TODO(), t.cycleNodeRequest); err != nil {
 			t.rm.Logger.Error(err, "Unable to delete expired CycleNodeRequest")
 		}
+
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions_pending_test.go
@@ -406,7 +406,7 @@ func TestPendingReattachedCloudProviderNode(t *testing.T) {
 	assert.NoError(t, err)
 
 	// "re-attach" the instance to the asg
-	fakeTransitioner.cloudProviderInstances[0].Nodegroup = "ng-1"
+	fakeTransitioner.CloudProviderInstances[0].Nodegroup = "ng-1"
 
 	// The CNR should transition to the Initialised phase because the state of
 	// the nodes is now correct and this happened within the timeout period.
@@ -474,7 +474,7 @@ func TestPendingReattachedCloudProviderNodeTooLate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// "re-attach" the instance to the asg
-	fakeTransitioner.cloudProviderInstances[0].Nodegroup = "ng-1"
+	fakeTransitioner.CloudProviderInstances[0].Nodegroup = "ng-1"
 
 	// This time should transition to the healing phase even though the state
 	// is correct because the timeout check happens first

--- a/pkg/controller/cyclenoderequest/transitioner/transitions_successful_test.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions_successful_test.go
@@ -1,0 +1,275 @@
+package transitioner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Test that if no delete options are given to the transitioner, then the CNR
+// will not be deleted.
+func TestSuccessfulNoDelete(t *testing.T) {
+	cnr := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cnr-1",
+			Namespace:         "kube-system",
+			CreationTimestamp: metav1.Now(),
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase:   v1.CycleNodeRequestSuccessful,
+			Message: "",
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr)
+
+	var list v1.CycleNodeRequestList
+
+	assert.NoError(t,
+		fakeTransitioner.Client.K8sClient.List(context.TODO(), &list, &client.ListOptions{}),
+	)
+
+	assert.Len(t, list.Items, 1)
+
+	// Execute the Successful phase
+	_, err := fakeTransitioner.Run()
+	assert.NoError(t, err)
+
+	assert.NoError(t,
+		fakeTransitioner.Client.K8sClient.List(context.TODO(), &list, &client.ListOptions{}),
+	)
+
+	assert.Len(t, list.Items, 1)
+}
+
+// Test that if the phase executes before the CNR deletion expiry time then the
+// CNR won't be deleted.
+func TestSuccessfulAfterDeleteTime(t *testing.T) {
+	cnr := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cnr-1",
+			Namespace:         "kube-system",
+			CreationTimestamp: metav1.Now(),
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase:   v1.CycleNodeRequestSuccessful,
+			Message: "",
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr,
+		WithTransitionerOptions(Options{
+			DeleteCNR:       true,
+			DeleteCNRExpiry: 0 * time.Second,
+		}),
+	)
+
+	var list v1.CycleNodeRequestList
+
+	assert.NoError(t,
+		fakeTransitioner.Client.K8sClient.List(context.TODO(), &list, &client.ListOptions{}),
+	)
+
+	assert.Len(t, list.Items, 1)
+
+	// Execute the Successful phase
+	_, err := fakeTransitioner.Run()
+	assert.NoError(t, err)
+
+	assert.NoError(t,
+		fakeTransitioner.Client.K8sClient.List(context.TODO(), &list, &client.ListOptions{}),
+	)
+
+	assert.Len(t, list.Items, 0)
+}
+
+// Test that if the phase executes after the CNR deletion expiry time then the
+// CNR will be deleted.
+func TestSuccessfulBeforeDeleteTime(t *testing.T) {
+	cnr := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cnr-1",
+			Namespace:         "kube-system",
+			CreationTimestamp: metav1.Now(),
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase:   v1.CycleNodeRequestSuccessful,
+			Message: "",
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr,
+		WithTransitionerOptions(Options{
+			DeleteCNR:       true,
+			DeleteCNRExpiry: 5 * time.Second,
+		}),
+	)
+
+	var list v1.CycleNodeRequestList
+
+	assert.NoError(t,
+		fakeTransitioner.Client.K8sClient.List(context.TODO(), &list, &client.ListOptions{}),
+	)
+
+	assert.Len(t, list.Items, 1)
+
+	// Execute the Successful phase
+	_, err := fakeTransitioner.Run()
+	assert.NoError(t, err)
+
+	assert.NoError(t,
+		fakeTransitioner.Client.K8sClient.List(context.TODO(), &list, &client.ListOptions{}),
+	)
+
+	assert.Len(t, list.Items, 1)
+}
+
+// Test that the Successful phase will delete sibling CNRs for the same
+// nodegroup that are in the failed phase. No other CNRs should be deleted.
+func TestSuccessfulDeleteFailedSiblingCNRs(t *testing.T) {
+	// CNR used for the execution
+	// Should not be deleted
+	cnr1 := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cnr-1",
+			Namespace:         "kube-system",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupName: "ng-1",
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase:   v1.CycleNodeRequestSuccessful,
+			Message: "",
+		},
+	}
+
+	// Failed CNR for the same nodegroup
+	// Should be deleted
+	cnr2 := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cnr-2",
+			Namespace:         "kube-system",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupName: "ng-1",
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase:   v1.CycleNodeRequestFailed,
+			Message: "",
+		},
+	}
+
+	// Pending CNR for the same nodegroup
+	// Should NOT be deleted
+	cnr3 := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cnr-3",
+			Namespace:         "kube-system",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupName: "ng-1",
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase:   v1.CycleNodeRequestPending,
+			Message: "",
+		},
+	}
+
+	// Failed CNR for a different nodegroup
+	// Should NOT be deleted
+	cnr4 := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cnr-4",
+			Namespace:         "kube-system",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupName: "ng-2",
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase:   v1.CycleNodeRequestFailed,
+			Message: "",
+		},
+	}
+
+	// Failed CNR for the same nodegroup in a different namespace
+	// Should NOT be deleted
+	cnr5 := &v1.CycleNodeRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cnr-5",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: v1.CycleNodeRequestSpec{
+			NodeGroupName: "ng-1",
+		},
+		Status: v1.CycleNodeRequestStatus{
+			Phase:   v1.CycleNodeRequestFailed,
+			Message: "",
+		},
+	}
+
+	fakeTransitioner := NewFakeTransitioner(cnr1,
+		WithExtraKubeObject(cnr2),
+		WithExtraKubeObject(cnr3),
+		WithExtraKubeObject(cnr4),
+		WithExtraKubeObject(cnr5),
+	)
+
+	var list v1.CycleNodeRequestList
+
+	assert.NoError(t,
+		fakeTransitioner.Client.K8sClient.List(context.TODO(), &list, &client.ListOptions{}),
+	)
+
+	assert.Len(t, list.Items, 5)
+
+	// Execute the Successful phase
+	_, err := fakeTransitioner.Run()
+	assert.NoError(t, err)
+
+	assert.NoError(t,
+		fakeTransitioner.Client.K8sClient.List(context.TODO(), &list, &client.ListOptions{}),
+	)
+
+	assert.Len(t, list.Items, 4)
+
+	var cnr v1.CycleNodeRequest
+
+	assert.NoError(t, fakeTransitioner.Client.K8sClient.Get(context.TODO(), types.NamespacedName{
+		Name:      cnr1.Name,
+		Namespace: cnr1.Namespace,
+	}, &cnr))
+
+	// CNR 2 is the only one that should be deleted
+	assert.Error(t, fakeTransitioner.Client.K8sClient.Get(context.TODO(), types.NamespacedName{
+		Name:      cnr2.Name,
+		Namespace: cnr2.Namespace,
+	}, &cnr))
+
+	assert.NoError(t, fakeTransitioner.Client.K8sClient.Get(context.TODO(), types.NamespacedName{
+		Name:      cnr3.Name,
+		Namespace: cnr3.Namespace,
+	}, &cnr))
+
+	assert.NoError(t, fakeTransitioner.Client.K8sClient.Get(context.TODO(), types.NamespacedName{
+		Name:      cnr4.Name,
+		Namespace: cnr4.Namespace,
+	}, &cnr))
+
+	assert.NoError(t, fakeTransitioner.Client.K8sClient.Get(context.TODO(), types.NamespacedName{
+		Name:      cnr5.Name,
+		Namespace: cnr5.Namespace,
+	}, &cnr))
+}

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -538,7 +538,7 @@ func (t *CycleNodeRequestTransitioner) validateInstanceState(validNodeGroupInsta
 }
 
 // deleteFailedSiblingCNRs finds the CNRs generated for the same nodegroup as
-// the one in the calling transitioner. It filters for deleted CNRs in the same
+// the one in the transitioner. It filters for deleted CNRs in the same
 // namespace and deletes them.
 func (t *CycleNodeRequestTransitioner) deleteFailedSiblingCNRs() error {
 	ctx := context.TODO()

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -564,8 +564,9 @@ func (t *CycleNodeRequestTransitioner) deleteFailedSiblingCNRs() error {
 			continue
 		}
 
-		// The Failed CNR should have been created prior to the CNR now in
-		// Successful otherwise new CNRs could fail and be cleaned up.
+		// The Failed CNR should have been created prior to or at the same time
+		// as the CNR now in Successful otherwise new CNRs could fail and be
+		// cleaned up.
 		if t.cycleNodeRequest.CreationTimestamp.Before(&cnr.CreationTimestamp) {
 			continue
 		}

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -564,6 +564,12 @@ func (t *CycleNodeRequestTransitioner) deleteFailedSiblingCNRs() error {
 			continue
 		}
 
+		// The Failed CNR should have been created prior to the CNR now in
+		// Successful otherwise new CNRs could fail and be cleaned up.
+		if t.cycleNodeRequest.CreationTimestamp.Before(&cnr.CreationTimestamp) {
+			continue
+		}
+
 		if err := t.rm.Client.Delete(ctx, &cnr); err != nil {
 			return err
 		}

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -535,7 +535,6 @@ func (t *CycleNodeRequestTransitioner) validateInstanceState(validNodeGroupInsta
 // namespace and deletes them.
 func (t *CycleNodeRequestTransitioner) deleteFailedSiblingCNRs() error {
 	ctx := context.TODO()
-	nodegroupList := t.cycleNodeRequest.GetNodeGroupNames()
 
 	var list v1.CycleNodeRequestList
 
@@ -549,7 +548,7 @@ func (t *CycleNodeRequestTransitioner) deleteFailedSiblingCNRs() error {
 
 	for _, cnr := range list.Items {
 		// Filter out CNRs generated for another Nodegroup
-		if !sameNodeGroups(nodegroupList, cnr.GetNodeGroupNames()) {
+		if !t.cycleNodeRequest.IsFromSameNodeGroup(cnr) {
 			continue
 		}
 
@@ -564,26 +563,4 @@ func (t *CycleNodeRequestTransitioner) deleteFailedSiblingCNRs() error {
 	}
 
 	return nil
-}
-
-// sameNodeGroups compares two lists of nodegroup names and check they are the
-// same. Ordering does not affect equality.
-func sameNodeGroups(groupA, groupB []string) bool {
-	if len(groupA) != len(groupB) {
-		return false
-	}
-
-	groupMap := make(map[string]struct{})
-
-	for _, group := range groupA {
-		groupMap[group] = struct{}{}
-	}
-
-	for _, group := range groupB {
-		if _, ok := groupMap[group]; !ok {
-			return false
-		}
-	}
-
-	return true
 }

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -253,9 +253,9 @@ func (c *controller) dropInProgressNodeGroups(nodeGroups v1.NodeGroupList, cnrs 
 				dropNodeGroup = true
 			}
 
-			// If the number of Failed CNRs crossed the thrshold in the
+			// If the number of Failed CNRs exceeds the threshold in the
 			// nodegroup then drop it
-			if failedCNRsFound >= nodeGroup.Spec.MaxFailedCycleNodeRequests {
+			if failedCNRsFound > nodeGroup.Spec.MaxFailedCycleNodeRequests {
 				dropNodeGroup = true
 			}
 		}

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -261,7 +261,12 @@ func (c *controller) dropInProgressNodeGroups(nodeGroups v1.NodeGroupList, cnrs 
 		}
 
 		if dropNodeGroup {
-			klog.Warningf("nodegroup %q has an in progress CNR.. skipping this nodegroup", nodeGroup.Name)
+			if failedCNRsFound > nodeGroup.Spec.MaxFailedCycleNodeRequests {
+				klog.Warningf("nodegroup %q has too many failed CNRs.. skipping this nodegroup", nodeGroup.Name)
+			} else {
+				klog.Warningf("nodegroup %q has an in progress CNR.. skipping this nodegroup", nodeGroup.Name)
+			}
+
 			c.NodeGroupsLocked.WithLabelValues(nodeGroup.Name).Inc()
 			continue
 		}

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -241,7 +241,7 @@ func (c *controller) dropInProgressNodeGroups(nodeGroups v1.NodeGroupList, cnrs 
 
 		for _, cnr := range cnrs.Items {
 			// CNR doesn't match nodegroup, skip it
-			if !sameNodeGroups(cnr.GetNodeGroupNames(), nodeGroup.GetNodeGroupNames()) {
+			if !cnr.IsFromNodeGroup(nodeGroup) {
 				continue
 			}
 
@@ -459,21 +459,4 @@ func (c *controller) RunForever() {
 			return
 		}
 	}
-}
-
-func sameNodeGroups(groupA, groupB []string) bool {
-	if len(groupA) != len(groupB) {
-		return false
-	}
-
-	groupMap := make(map[string]struct{})
-	for _, group := range groupA {
-		groupMap[group] = struct{}{}
-	}
-	for _, group := range groupB {
-		if _, ok := groupMap[group]; !ok {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/observer/controller_test.go
+++ b/pkg/observer/controller_test.go
@@ -384,47 +384,6 @@ func Test_dropInProgressNodeGroups(t *testing.T) {
 	}
 }
 
-func Test_sameNodeGroups(t *testing.T) {
-	tests := []struct {
-		name   string
-		groupA []string
-		groupB []string
-		expect bool
-	}{
-		{
-			"pass case with same order",
-			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
-			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
-			true,
-		},
-		{
-			"pass case with different order",
-			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
-			[]string{"ingress-us-west-2b", "ingress-us-west-2c", "ingress-us-west-2a"},
-			true,
-		},
-		{
-			"failure case with different length",
-			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
-			[]string{"ingress-us-west-2b", "ingress-us-west-2c"},
-			false,
-		},
-		{
-			"failure case with different items",
-			[]string{"ingress-us-west-2a", "ingress-us-west-2b", "ingress-us-west-2c"},
-			[]string{"ingress-us-west-2b", "ingress-us-west-2c", "system"},
-			false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := sameNodeGroups(tt.groupA, tt.groupB)
-			assert.Equal(t, tt.expect, got)
-		})
-	}
-}
-
 func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.Client {
 	return fake.NewClientBuilder().WithScheme(clientScheme).WithRuntimeObjects(initObjs...).Build()
 }


### PR DESCRIPTION
- Adding a new `maxFailedCycleNodeRequests` attribute to the `NodeGroup` spec which defines how many failed CNRs are allowed for a nodegroup before observer will stop generating new ones. The equivalent to the current behaviour is `maxFailedCycleNodeRequests: 0`. This is not a breaking change.
- The Cyclops controller will now delete any sibling failed CNRs when a new one reaches the `Successful` phase.
- The `cyclops_cycle_node_requests_by_phase` metric has been update to include a new `nodegroup` attribute which is the name of the nodegroup the CNR was generated from. Manually created CNRs that don't match a nodegroup will include the attribute with an empty string.