### PR TITLE
Log out detailed node mismatch message

### DIFF
--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -506,10 +506,14 @@ func (t *CycleNodeRequestTransitioner) logProblemNodes(nodesNotInCloudProviderNo
 		offendingNodesInfo += strings.Join(providerIDs, ",")
 	}
 
-	t.rm.LogEvent(t.cycleNodeRequest, "NodeStateInvalid",
-		"instances missing: %v, kube nodes missing: %v. %v",
+	message := fmt.Sprintf("instances missing: %v, kube nodes missing: %v. %v",
 		len(nodesNotInCloudProviderNodegroup), len(instancesNotInKube), offendingNodesInfo,
 	)
+
+	// Send to both so because this is important info that needs to be found
+	// more easily
+	t.rm.Logger.Info(message)
+	t.rm.LogEvent(t.cycleNodeRequest, "NodeStateInvalid", message)
 }
 
 // validateInstanceState performs final validation on the nodegroup to ensure

--- a/pkg/controller/cyclenoderequest/transitioner/util.go
+++ b/pkg/controller/cyclenoderequest/transitioner/util.go
@@ -506,8 +506,11 @@ func (t *CycleNodeRequestTransitioner) logProblemNodes(nodesNotInCloudProviderNo
 		offendingNodesInfo += strings.Join(providerIDs, ",")
 	}
 
-	message := fmt.Sprintf("instances missing: %v, kube nodes missing: %v. %v",
-		len(nodesNotInCloudProviderNodegroup), len(instancesNotInKube), offendingNodesInfo,
+	message := fmt.Sprintf(
+		"instances missing from cloud provider nodegroup: %v, kube nodes missing: %v. %v",
+		len(nodesNotInCloudProviderNodegroup),
+		len(instancesNotInKube),
+		offendingNodesInfo,
 	)
 
 	// Send to both so because this is important info that needs to be found


### PR DESCRIPTION
Adding this because events may not persist and having this in logs too makes it easier to investigate issues related to nodes mismatching.