### PR TITLE
remove safeToStartCycle check

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,5 +16,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.63
           args: --timeout=5m

--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -37,7 +37,6 @@ type app struct {
 	cloudProviderName        *string
 	namespace                *string
 	addr                     *string
-	prometheusAddress        *string
 	dryMode                  *bool
 	runImmediately           *bool
 	runOnce                  *bool
@@ -50,18 +49,16 @@ type app struct {
 // newApp creates a new app and sets up the cobra flags
 func newApp(rootCmd *cobra.Command) *app {
 	return &app{
-		addr:                     rootCmd.PersistentFlags().String("addr", ":8080", "Address to listen on for /metrics"),
-		cloudProviderName:        rootCmd.PersistentFlags().String("cloud-provider", "aws", "Which cloud provider to use, options: [aws]"),
-		namespaces:               rootCmd.PersistentFlags().StringSlice("namespaces", []string{"kube-system"}, "Namespaces to watch for cycle request objects"),
-		namespace:                rootCmd.PersistentFlags().String("namespace", "kube-system", "Namespaces to watch and create cnrs"),
-		dryMode:                  rootCmd.PersistentFlags().Bool("dry", false, "api-server drymode for applying CNRs"),
-		waitInterval:             rootCmd.PersistentFlags().Duration("wait-interval", 2*time.Minute, "duration to wait after detecting changes before creating CNR objects. The window for letting changes on nodegroups settle before starting rotation"),
-		checkInterval:            rootCmd.PersistentFlags().Duration("check-interval", 5*time.Minute, `duration interval to check for changes. e.g. run the loop every 5 minutes"`),
-		nodeStartupTime:          rootCmd.PersistentFlags().Duration("node-startup-time", 2*time.Minute, "duration to wait after a cluster-autoscaler scaleUp event is detected"),
-		runImmediately:           rootCmd.PersistentFlags().Bool("now", false, "makes the check loop run straight away on program start rather than wait for the check interval to elapse"),
-		runOnce:                  rootCmd.PersistentFlags().Bool("once", false, "run the check loop once then exit. also works with --now"),
-		prometheusAddress:        rootCmd.PersistentFlags().String("prometheus-address", "prometheus", "Prometheus service address used to query cluster-autoscaler metrics"),
-		prometheusScrapeInterval: rootCmd.PersistentFlags().Duration("prometheus-scrape-interval", 40*time.Second, "Prometheus scrape interval used to detect change of value from prometheus query, needed to detect scaleUp event"),
+		addr:              rootCmd.PersistentFlags().String("addr", ":8080", "Address to listen on for /metrics"),
+		cloudProviderName: rootCmd.PersistentFlags().String("cloud-provider", "aws", "Which cloud provider to use, options: [aws]"),
+		namespaces:        rootCmd.PersistentFlags().StringSlice("namespaces", []string{"kube-system"}, "Namespaces to watch for cycle request objects"),
+		namespace:         rootCmd.PersistentFlags().String("namespace", "kube-system", "Namespaces to watch and create cnrs"),
+		dryMode:           rootCmd.PersistentFlags().Bool("dry", false, "api-server drymode for applying CNRs"),
+		waitInterval:      rootCmd.PersistentFlags().Duration("wait-interval", 2*time.Minute, "duration to wait after detecting changes before creating CNR objects. The window for letting changes on nodegroups settle before starting rotation"),
+		checkInterval:     rootCmd.PersistentFlags().Duration("check-interval", 5*time.Minute, `duration interval to check for changes. e.g. run the loop every 5 minutes"`),
+		nodeStartupTime:   rootCmd.PersistentFlags().Duration("node-startup-time", 2*time.Minute, "duration to wait after a cluster-autoscaler scaleUp event is detected"),
+		runImmediately:    rootCmd.PersistentFlags().Bool("now", false, "makes the check loop run straight away on program start rather than wait for the check interval to elapse"),
+		runOnce:           rootCmd.PersistentFlags().Bool("once", false, "run the check loop once then exit. also works with --now"),
 	}
 }
 
@@ -126,7 +123,6 @@ func (a *app) run() {
 		RunOnce:                  *a.runOnce,
 		WaitInterval:             *a.waitInterval,
 		NodeStartupTime:          *a.nodeStartupTime,
-		PrometheusAddress:        *a.prometheusAddress,
 		PrometheusScrapeInterval: *a.prometheusScrapeInterval,
 	}
 

--- a/pkg/controller/cyclenoderequest/transitioner/transitions.go
+++ b/pkg/controller/cyclenoderequest/transitioner/transitions.go
@@ -48,7 +48,7 @@ func (t *CycleNodeRequestTransitioner) transitionUndefined() (reconcile.Result, 
 	validationErrors := validation.IsDNS1035Label(t.cycleNodeRequest.Name)
 
 	if len(validationErrors) > 0 {
-		return t.transitionToFailed(fmt.Errorf(strings.Join(validationErrors, ",")))
+		return t.transitionToFailed(fmt.Errorf("%s", strings.Join(validationErrors, ",")))
 	}
 
 	// Transition the object to pending

--- a/pkg/controller/cyclenodestatus/transitioner/transitions.go
+++ b/pkg/controller/cyclenodestatus/transitioner/transitions.go
@@ -153,7 +153,7 @@ func (t *CycleNodeStatusTransitioner) transitionDraining() (reconcile.Result, er
 	// Fail with all of the combined encountered errors if we got any. If we failed inside the loop we would
 	// potentially miss some important information in the logs.
 	if len(unexpectedErrors) > 0 {
-		return t.transitionToFailed(fmt.Errorf(strings.Join(unexpectedErrors, "\n")))
+		return t.transitionToFailed(fmt.Errorf("%s", strings.Join(unexpectedErrors, "\n")))
 	}
 	// No serious errors were encountered. If we're done, move on.
 	if finished {

--- a/pkg/observer/types.go
+++ b/pkg/observer/types.go
@@ -21,10 +21,9 @@ type Controller interface {
 
 // Options contains the options config for a controller
 type Options struct {
-	CNRPrefix         string
-	Namespace         string
-	CheckSchedule     string
-	PrometheusAddress string
+	CNRPrefix     string
+	Namespace     string
+	CheckSchedule string
 
 	DryMode        bool
 	RunImmediately bool


### PR DESCRIPTION
This section of code does not behave as intended. It was introduced in 2020 to attempt to fix a race condition between the observer and cluster autoscaler. Due to recent improvements, the race condition is now solved so this code can be removed.

**Why does this code not work?**
From https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/metrics.md#cluster-autoscaler-execution

> `last_activity` records last time certain part of cluster autoscaler logic executed. Represented with unix timestamp. autoscaler-activity values are:
> 
> main - main loop iteration started.
> 
> autoscaling - current state of the cluster has been updated, started autoscaling logic.
> 
> scaleUp - autoscaler will check if scale up is necessary.
> 
> scaleDown - autoscaler will try to scale down some nodes.

The `last_activity` metric reflects whether cluster autoscaler has attempted to scale up or down. However, it does not necessarily indicate actual changes in the ASG, resulting in numerous false positives. This behaviour can unnecessarily block the creation of CNRs, even when it is safe to proceed with cycling.
