### PR TITLE
remove unused commandline flags from observer

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -33,17 +33,16 @@ var (
 
 // app type holds options for the application from cobra
 type app struct {
-	namespaces               *[]string
-	cloudProviderName        *string
-	namespace                *string
-	addr                     *string
-	dryMode                  *bool
-	runImmediately           *bool
-	runOnce                  *bool
-	checkInterval            *time.Duration
-	waitInterval             *time.Duration
-	nodeStartupTime          *time.Duration
-	prometheusScrapeInterval *time.Duration
+	namespaces        *[]string
+	cloudProviderName *string
+	namespace         *string
+	addr              *string
+	dryMode           *bool
+	runImmediately    *bool
+	runOnce           *bool
+	checkInterval     *time.Duration
+	waitInterval      *time.Duration
+	nodeStartupTime   *time.Duration
 }
 
 // newApp creates a new app and sets up the cobra flags
@@ -115,15 +114,14 @@ func (a *app) run() {
 	}
 
 	options := observer.Options{
-		CNRPrefix:                "observer",
-		Namespace:                *a.namespace,
-		CheckInterval:            *a.checkInterval,
-		DryMode:                  *a.dryMode,
-		RunImmediately:           *a.runImmediately,
-		RunOnce:                  *a.runOnce,
-		WaitInterval:             *a.waitInterval,
-		NodeStartupTime:          *a.nodeStartupTime,
-		PrometheusScrapeInterval: *a.prometheusScrapeInterval,
+		CNRPrefix:       "observer",
+		Namespace:       *a.namespace,
+		CheckInterval:   *a.checkInterval,
+		DryMode:         *a.dryMode,
+		RunImmediately:  *a.runImmediately,
+		RunOnce:         *a.runOnce,
+		WaitInterval:    *a.waitInterval,
+		NodeStartupTime: *a.nodeStartupTime,
 	}
 
 	go awaitStopSignal(stopCh)

--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -220,8 +220,6 @@ Flags:
       --node-startup-time duration            duration to wait after a cluster-autoscaler scaleUp event is detected (default 2m0s)
       --now                                   makes the check loop run straight away on program start rather than wait for the check interval to elapse
       --once                                  run the check loop once then exit. also works with --now
-      --prometheus-address string             Prometheus service address used to query cluster-autoscaler metrics (default "prometheus")
-      --prometheus-scrape-interval duration   Prometheus scrape interval used to detect change of value from prometheus query, needed to detect scaleUp event (default 40s)
       --skip_headers                          If true, avoid header prefixes in the log messages
       --skip_log_headers                      If true, avoid headers when opening log files
       --stderrthreshold severity              logs at or above this threshold go to stderr

--- a/pkg/observer/types.go
+++ b/pkg/observer/types.go
@@ -29,10 +29,9 @@ type Options struct {
 	RunImmediately bool
 	RunOnce        bool
 
-	CheckInterval            time.Duration
-	WaitInterval             time.Duration
-	NodeStartupTime          time.Duration
-	PrometheusScrapeInterval time.Duration
+	CheckInterval   time.Duration
+	WaitInterval    time.Duration
+	NodeStartupTime time.Duration
 }
 
 // ListedNodeGroups defines a type that contains a NodeGroup, a List of Nodes for that NodeGroup, and an optional Reason for why they are there


### PR DESCRIPTION
follow up of https://github.com/atlassian-labs/cyclops/pull/91

`prometheusScrapeInterval` was not removed cleanly