### PR TITLE
fix observer cli error

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
 	"k8s.io/client-go/kubernetes"
@@ -28,7 +29,7 @@ import (
 var (
 	// replaced by ldflags at buildtime
 	version = "undefined" //nolint:golint,varcheck,deadcode,unused
-	klogger = textlogger.NewLogger(&textlogger.Config{})
+	klogger logr.Logger
 )
 
 // app type holds options for the application from cobra
@@ -189,6 +190,9 @@ func main() {
 		Long:  "detects changes on nodegroups for both cloud instances out of date with ASGs and OnDelete pods of DaemonSets. Will create CNRs to automatically cycle affected nodes",
 
 		Run: func(*cobra.Command, []string) {
+			loggerConfig := textlogger.NewConfig()
+			klogger = textlogger.NewLogger(loggerConfig)
+
 			a.run()
 		},
 	}


### PR DESCRIPTION
It looks like changes from the [previous PR](https://github.com/atlassian-labs/cyclops/pull/93/files#diff-c396d8ee377761a43fca284545cb4ee535f868ea2b16db01db81a21741855ed8L31) caused the following error when it started, need to initialize the logger properly. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1866743]

goroutine 1 [running]:
k8s.io/klog/v2/internal/verbosity.(*VState).Enabled(0x50be1f?, 0x0?, 0x2714a20?)
        /go/pkg/mod/k8s.io/klog/v2@v2.130.1/internal/verbosity/verbosity.go:252 +0x23
k8s.io/klog/v2/textlogger.(*tlogger).Enabled(0x50c29a?, 0xc000a384e0?)
        /go/pkg/mod/k8s.io/klog/v2@v2.130.1/textlogger/textlogger.go:83 +0x25
github.com/go-logr/logr.Logger.Info({{0x2c256b8?, 0xc000550680?}, 0xc00060f850?}, {0xc00110c0a0, 0x47}, {0x0, 0x0, 0x0})
        /go/pkg/mod/github.com/go-logr/logr@v1.4.2/logr.go:276 +0x6e
github.com/atlassian-labs/cyclops/pkg/cloudprovider/aws.NewCloudProvider({{0x2c256b8?, 0xc000550680?}, 0x27a2a7c?})
        /go/src/github.com/atlassian-labs/cyclops/pkg/cloudprovider/aws/builder.go:40 +0x2dd
```