### PR TITLE
Add priority-based node cycling with dedup, retries, and metrics

### DIFF
--- a/pkg/apis/atlassian/v1/cyclenoderequest_types.go
+++ b/pkg/apis/atlassian/v1/cyclenoderequest_types.go
@@ -42,6 +42,16 @@ type CycleNodeRequestSpec struct {
 
 	// SkipPreTerminationChecks is an optional flag to skip pre-termination checks during cycling
 	SkipPreTerminationChecks bool `json:"skipPreTerminationChecks,omitempty"`
+
+	// Priority: 0 = highest priority, 1 = lower priority
+	Priority int32 `json:"priority,omitempty"`
+		
+	// Must be healthy before higher priority groups cycle
+	RequiredForNextPriority bool `json:"requiredForNextPriority,omitempty"`
+
+	// AutoStart determines if this CNR should start automatically when dependencies are met
+	// If false, the CNR will be created but not activated until triggered by the observer
+	AutoStart bool `json:"autoStart,omitempty"`
 }
 
 // CycleNodeRequestStatus defines the observed state of CycleNodeRequest

--- a/pkg/apis/atlassian/v1/cyclenoderequest_types.go
+++ b/pkg/apis/atlassian/v1/cyclenoderequest_types.go
@@ -43,15 +43,10 @@ type CycleNodeRequestSpec struct {
 	// SkipPreTerminationChecks is an optional flag to skip pre-termination checks during cycling
 	SkipPreTerminationChecks bool `json:"skipPreTerminationChecks,omitempty"`
 
-	// Priority: 0 = highest priority, 1 = lower priority
+	// Priority: 0 = higher priority, 1 = lower priority
+	// Higher priority groups cycle first. All lower priority groups must be healthy before higher priority groups cycle.
 	Priority int32 `json:"priority,omitempty"`
-		
-	// Must be healthy before higher priority groups cycle
-	RequiredForNextPriority bool `json:"requiredForNextPriority,omitempty"`
 
-	// AutoStart determines if this CNR should start automatically when dependencies are met
-	// If false, the CNR will be created but not activated until triggered by the observer
-	AutoStart bool `json:"autoStart,omitempty"`
 }
 
 // CycleNodeRequestStatus defines the observed state of CycleNodeRequest

--- a/pkg/apis/atlassian/v1/nodegroup_types.go
+++ b/pkg/apis/atlassian/v1/nodegroup_types.go
@@ -40,11 +40,10 @@ type NodeGroupSpec struct {
 	// SkipPreTerminationChecks is an optional flag to skip pre-termination checks during cycling
 	SkipPreTerminationChecks bool `json:"skipPreTerminationChecks,omitempty"`
 
-	// Priority: 0 = highest priority (default nodes), 1 = lower priority (system nodes)
+	// Priority: 0 = higher priority, 1 = lower priority
+	// Higher priority groups cycle first. All lower priority groups must be healthy before higher priority groups cycle.
 	Priority int32 `json:"priority,omitempty"`
-		
-	// Must be healthy before higher priority groups cycle
-	RequiredForNextPriority bool `json:"requiredForNextPriority,omitempty"`
+
 }
 
 // NodeGroupStatus defines the observed state of NodeGroup

--- a/pkg/apis/atlassian/v1/nodegroup_types.go
+++ b/pkg/apis/atlassian/v1/nodegroup_types.go
@@ -39,6 +39,12 @@ type NodeGroupSpec struct {
 
 	// SkipPreTerminationChecks is an optional flag to skip pre-termination checks during cycling
 	SkipPreTerminationChecks bool `json:"skipPreTerminationChecks,omitempty"`
+
+	// Priority: 0 = highest priority (default nodes), 1 = lower priority (system nodes)
+	Priority int32 `json:"priority,omitempty"`
+		
+	// Must be healthy before higher priority groups cycle
+	RequiredForNextPriority bool `json:"requiredForNextPriority,omitempty"`
 }
 
 // NodeGroupStatus defines the observed state of NodeGroup

--- a/pkg/generation/cnr.go
+++ b/pkg/generation/cnr.go
@@ -102,12 +102,6 @@ func GenerateCNR(nodeGroup atlassianv1.NodeGroup, nodes []string, name, namespac
 		priority = int32(nodeGroup.Spec.Priority)
 	}
 
-    // Set RequiredForNextPriority based on NodeGroup setting
-    requiredForNextPriority := false
-    if nodeGroup.Spec.RequiredForNextPriority {
-        requiredForNextPriority = true
-    }
-
 	return atlassianv1.CycleNodeRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      finalName,
@@ -123,7 +117,6 @@ func GenerateCNR(nodeGroup atlassianv1.NodeGroup, nodes []string, name, namespac
 			PreTerminationChecks:     nodeGroup.Spec.PreTerminationChecks,
 			SkipInitialHealthChecks:  nodeGroup.Spec.SkipInitialHealthChecks,
 			SkipPreTerminationChecks: nodeGroup.Spec.SkipPreTerminationChecks,
-			RequiredForNextPriority:  requiredForNextPriority,
 			Priority:                 priority,
 			ValidationOptions:        nodeGroup.Spec.ValidationOptions,
 		},
@@ -133,7 +126,7 @@ func GenerateCNR(nodeGroup atlassianv1.NodeGroup, nodes []string, name, namespac
 // ActivateCNR activates a single CNR
 func ActivateCNR(cnr *atlassianv1.CycleNodeRequest) {
     // Update status to indicate activation
-    cnr.Status.Phase = "Pending"
+    cnr.Status.Phase = atlassianv1.CycleNodeRequestPending
     cnr.Status.Message = fmt.Sprintf("Activated by priority system at %s", 
 	metav1.Now())
 }

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -27,7 +26,6 @@ type controller struct {
 	observers  map[string]Observer
 
 	optimisedOrder []timedKey
-	priorityLock   priorityActivationLock
 
 	*metrics
 	Options
@@ -38,13 +36,6 @@ type controller struct {
 type timedKey struct {
 	duration time.Duration
 	key      string
-}
-
-// priorityActivationLock prevents race conditions during priority activation
-type priorityActivationLock struct {
-	mu sync.Mutex
-	activePriority int32
-	isActivating bool
 }
 
 // runMetricsHandler creates the metrics struct for the controller and starts the handler and server

--- a/pkg/observer/controller.go
+++ b/pkg/observer/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -26,6 +27,7 @@ type controller struct {
 	observers  map[string]Observer
 
 	optimisedOrder []timedKey
+	priorityLock   priorityActivationLock
 
 	*metrics
 	Options
@@ -36,6 +38,13 @@ type controller struct {
 type timedKey struct {
 	duration time.Duration
 	key      string
+}
+
+// priorityActivationLock prevents race conditions during priority activation
+type priorityActivationLock struct {
+	mu sync.Mutex
+	activePriority int32
+	isActivating bool
 }
 
 // runMetricsHandler creates the metrics struct for the controller and starts the handler and server

--- a/pkg/observer/metrics.go
+++ b/pkg/observer/metrics.go
@@ -19,11 +19,7 @@ type metrics struct {
 	PriorityActions            *prometheus.CounterVec
 	PriorityLevelHealth        *prometheus.GaugeVec
 	PriorityActivationDuration *prometheus.HistogramVec
-	
-	// Race condition prevention metrics
 	RaceConditionPrevention   *prometheus.CounterVec
-	
-	// Deduplication metrics
 	CNRDeduplication         *prometheus.CounterVec
 }
 

--- a/pkg/observer/metrics.go
+++ b/pkg/observer/metrics.go
@@ -19,6 +19,12 @@ type metrics struct {
 	PriorityActions            *prometheus.CounterVec
 	PriorityLevelHealth        *prometheus.GaugeVec
 	PriorityActivationDuration *prometheus.HistogramVec
+	
+	// Race condition prevention metrics
+	RaceConditionPrevention   *prometheus.CounterVec
+	
+	// Deduplication metrics
+	CNRDeduplication         *prometheus.CounterVec
 }
 
 // newMetrics creates the new controller metrics struct
@@ -82,6 +88,26 @@ func newMetrics() *metrics {
 				Buckets:   prometheus.DefBuckets,
 			},
 			[]string{"priority"},
+		),
+		
+		// Race condition prevention metrics
+		RaceConditionPrevention: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name:      "race_condition_prevention_total",
+				Namespace: metricsNamespace,
+				Help:      "Total number of race conditions prevented",
+			},
+			[]string{"type"},
+		),
+		
+		// Deduplication metrics
+		CNRDeduplication: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name:      "cnr_deduplication_total",
+				Namespace: metricsNamespace,
+				Help:      "Total number of CNR deduplication events",
+			},
+			[]string{"nodegroup", "reason"},
 		),
 	}
 }

--- a/pkg/observer/metrics.go
+++ b/pkg/observer/metrics.go
@@ -16,6 +16,9 @@ type metrics struct {
 	CNRsCreated         *prometheus.CounterVec
 	NodeGroupsLocked    *prometheus.CounterVec
 	ObserverRunTimes    *prometheus.GaugeVec
+	PriorityActions            *prometheus.CounterVec
+	PriorityLevelHealth        *prometheus.GaugeVec
+	PriorityActivationDuration *prometheus.HistogramVec
 }
 
 // newMetrics creates the new controller metrics struct
@@ -52,6 +55,33 @@ func newMetrics() *metrics {
 				Help:      "gauge of observer runtimes in seconds",
 			},
 			[]string{"observer"},
+		),
+		
+		// Priority-specific metrics
+		PriorityActions: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name:      "priority_actions_total",
+				Namespace: metricsNamespace,
+				Help:      "Total number of priority actions performed",
+			},
+			[]string{"priority", "action"},
+		),
+		PriorityLevelHealth: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name:      "priority_level_health",
+				Namespace: metricsNamespace,
+				Help:      "Health status of priority levels (1 = healthy, 0 = unhealthy)",
+			},
+			[]string{"priority"},
+		),
+		PriorityActivationDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:      "priority_activation_duration_seconds",
+				Namespace: metricsNamespace,
+				Help:      "Time taken to activate priority levels",
+				Buckets:   prometheus.DefBuckets,
+			},
+			[]string{"priority"},
 		),
 	}
 }

--- a/pkg/observer/priority.go
+++ b/pkg/observer/priority.go
@@ -104,8 +104,8 @@ func (c *controller) canActivatePriorityLevel(priority int32, allCNRs []v1.Cycle
 	}
 
 	// Higher priorities: Wait for all lower priorities to complete and be healthy
-	for checkPriority := range priority {
-		if !c.isPriorityLevelHealthy(int32(checkPriority)) {
+	for checkPriority := int32(0); checkPriority < priority; checkPriority++ {
+		if !c.isPriorityLevelHealthy(checkPriority) {
 			return false
 		}
 	}

--- a/pkg/observer/priority.go
+++ b/pkg/observer/priority.go
@@ -1,0 +1,217 @@
+package observer
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
+	"github.com/atlassian-labs/cyclops/pkg/generation"
+)
+
+// groupByPriority groups node groups by their priority
+func (c *controller) groupByPriority(changedNodeGroups []*ListedNodeGroups) map[int32][]*ListedNodeGroups {
+	priorityGroups := make(map[int32][]*ListedNodeGroups)
+
+	for _, nodeGroup := range changedNodeGroups {
+		priority := c.getPriority(nodeGroup.NodeGroup)
+		priorityGroups[priority] = append(priorityGroups[priority], nodeGroup)
+	}
+
+	return priorityGroups
+}
+
+// createCNRs creates CNRs with priority-based staging
+func (c *controller) createCNRs(changedNodeGroups []*ListedNodeGroups) {
+	priorityGroups := c.groupByPriority(changedNodeGroups)
+
+	// Create ALL CNRs upfront - priority 0 starts immediately, others wait
+	for priority, groups := range priorityGroups {
+		for _, group := range groups {
+			nodeNames := make([]string, 0, len(group.List))
+			for _, node := range group.List {
+				nodeNames = append(nodeNames, node.Name)
+			}
+
+			// Generate CNR
+			cnr := generation.GenerateCNR(*group.NodeGroup, nodeNames, c.CNRPrefix, c.Namespace)
+			generation.UseGenerateNameCNR(&cnr)
+			generation.GiveReason(&cnr, group.Reason)
+			generation.SetAPIVersion(&cnr, apiVersion)
+
+			// Priority 0 starts immediately, others wait for activation
+			cnr.Spec.Priority = priority
+
+			name := generation.GetName(cnr.ObjectMeta)
+
+			if err := generation.ApplyCNR(c.client, c.DryMode, cnr); err != nil {
+				klog.Errorf("failed to apply cnr %q for nodegroup %q: %s", name, group.NodeGroup.Name, err)
+			} else {
+				var drymodeStr string
+				if c.DryMode {
+					drymodeStr = "[drymode] "
+				}
+				klog.V(2).Infof("%screated cnr %q for nodegroup %q (priority %d)",
+					drymodeStr, name, group.NodeGroup.Name, priority)
+				c.CNRsCreated.WithLabelValues(group.NodeGroup.Name).Inc()
+			}
+		}
+	}
+}
+
+// getPriority returns the priority of a node group
+func (c *controller) getPriority(nodeGroup *v1.NodeGroup) int32 {
+	// Check if NodeGroup has priority field set
+	if nodeGroup.Spec.Priority > 0 {
+		return nodeGroup.Spec.Priority
+	}
+
+	// Default to priority 0 for backward compatibility
+	return 0
+}
+
+// findNextActivatablePriority finds the lowest priority that can be activated
+func (c *controller) findNextActivatablePriority(allCNRs []v1.CycleNodeRequest) int32 {
+	// Find the highest priority level that exists
+	maxPriority := int32(-1)
+	for _, cnr := range allCNRs {
+		if cnr.Spec.Priority > maxPriority {
+			maxPriority = cnr.Spec.Priority
+		}
+	}
+	
+	// Check priorities in order from 0 to maxPriority
+	for priority := int32(0); priority <= maxPriority; priority++ {
+		if c.canActivatePriorityLevel(priority, allCNRs) {
+			return priority
+		}
+	}
+	return -1 // No priority can be activated
+}
+
+// canActivatePriorityLevel checks if all CNRs at a priority level can be activated
+func (c *controller) canActivatePriorityLevel(priority int32, allCNRs []v1.CycleNodeRequest) bool {
+	// Get all CNRs at this priority level
+	priorityCNRs := c.getCNRsAtPriority(priority, allCNRs)
+	if len(priorityCNRs) == 0 {
+		return false // No CNRs at this priority
+	}
+
+	// Priority 0: Always activate immediately
+	if priority == 0 {
+		return true
+	}
+
+	// Higher priorities: Wait for all lower priorities to complete and be healthy
+	for checkPriority := range priority {
+		if !c.isPriorityLevelHealthy(int32(checkPriority)) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// activatePriorityLevel activates all CNRs at a specific priority level
+func (c *controller) activatePriorityLevel(priority int32, allCNRs []v1.CycleNodeRequest) {
+	priorityCNRs := c.getCNRsAtPriority(priority, allCNRs)
+
+	klog.V(1).Infof("Activating priority level %d with %d CNRs",
+		priority, len(priorityCNRs))
+
+	for _, cnr := range priorityCNRs {
+		// Activate the CNR
+		generation.ActivateCNR(&cnr)
+
+		// Update the CNR in the cluster
+		if err := c.client.Update(context.Background(), &cnr); err != nil {
+			klog.Errorf("Failed to activate CNR %s: %v", cnr.Name, err)
+		} else {
+			klog.V(2).Infof("Activated CNR %s (priority %d)", cnr.Name, priority)
+		}
+	}
+}
+
+// checkAndActivateNextPriority finds and activates the next available priority level
+func (c *controller) checkAndActivateNextPriority() {
+	cnrs, err := generation.ListCNRs(c.client, &client.ListOptions{})
+	if err != nil {
+		klog.Errorf("failed to list CNRs: %v", err)
+		return
+	}
+
+	// Find the lowest priority CNR that can be activated
+	nextPriority := c.findNextActivatablePriority(cnrs.Items)
+	if nextPriority == -1 {
+		return // No CNRs can be activated
+	}
+
+	// Activate all CNRs at this priority level
+	c.activatePriorityLevel(nextPriority, cnrs.Items)
+}
+
+// getCNRsAtPriority gets all CNRs at a specific priority level
+func (c *controller) getCNRsAtPriority(priority int32, allCNRs []v1.CycleNodeRequest) []v1.CycleNodeRequest {
+	var priorityCNRs []v1.CycleNodeRequest
+
+	for _, cnr := range allCNRs {
+		if cnr.Spec.Priority == priority {
+			priorityCNRs = append(priorityCNRs, cnr)
+		}
+	}
+
+	return priorityCNRs
+}
+
+// isPriorityLevelHealthy checks if nodes at a priority level are healthy
+func (c *controller) isPriorityLevelHealthy(priority int32) bool {
+	// Get CNRs at this priority level
+	cnrs, err := generation.ListCNRs(c.client, &client.ListOptions{})
+	if err != nil {
+		klog.Errorf("failed to list CNRs for health check: %v", err)
+		return false
+	}
+
+	priorityCNRs := c.getCNRsAtPriority(priority, cnrs.Items)
+
+	for _, cnr := range priorityCNRs {
+		// Check if CNR is complete
+        if cnr.Status.Phase != v1.CycleNodeRequestSuccessful {
+            klog.V(2).Infof("CNR %s not yet complete (phase: %s)", cnr.Name, cnr.Status.Phase)
+            return false
+        }
+
+		// Check if health checks are configured and passed
+		if len(cnr.Spec.HealthChecks) > 0 {
+			if !c.checkCyclopsHealthChecks(&cnr) {
+				klog.V(2).Infof("Health checks not passed for CNR %s", cnr.Name)
+				return false
+			}
+		}
+	}
+
+	klog.V(2).Infof("All CNRs at priority %d are complete and healthy", priority)
+	return true
+}
+
+// checkCyclopsHealthChecks checks if Cyclops health checks have passed
+func (c *controller) checkCyclopsHealthChecks(cnr *v1.CycleNodeRequest) bool {
+	// Check if health checks are configured
+	if len(cnr.Spec.HealthChecks) == 0 {
+		return true // No health checks configured, consider healthy
+	}
+
+	// Check if all nodes have passed health checks
+	for nodeHash, healthStatus := range cnr.Status.HealthChecks {
+		// Check if all health checks for this node have passed
+		for i, passed := range healthStatus.Checks {
+			if !passed {
+				klog.V(2).Infof("Health check %d for node %s has not passed", i, nodeHash)
+				return false
+			}
+		}
+	}
+
+	return true
+} 


### PR DESCRIPTION

### Summary
Implements staged priority-based node cycling in Cyclops. All CNRs are created upfront for visibility and then activated sequentially by ascending priority once lower priorities complete successfully and pass health checks. 
Adds performance optimisations, retry logic, deduplication, and metrics. 

### Motivation
Prevent cluster degradation by ensuring default node groups are healthy before cycling system node groups.
Provides visibility into the entire cycling plan and allow on-the-fly priority changes.

### How it works
All CNRs are generated and applied in a dormant/Pending state grouped by Spec.Priority.
Activation loop finds the next eligible priority: all lower priorities must be Successful and pass health checks.
Priority N is activated only when N-1 is healthy; activation proceeds level-by-level.

### Backward compatibility
Priority defaults to 0 for older specs or invalid values.
CNR activation remains driven by priority level






