### PR TITLE
fix version check and aws creds issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.10.4
+VERSION = 1.10.3
 # IMPORTANT! Update api version if a new release affects cnr
 API_VERSION = 1.0.0
 IMAGE = cyclops:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.10.3
+VERSION = 1.10.4
 # IMPORTANT! Update api version if a new release affects cnr
 API_VERSION = 1.0.0
 IMAGE = cyclops:$(VERSION)

--- a/pkg/cloudprovider/aws/builder.go
+++ b/pkg/cloudprovider/aws/builder.go
@@ -6,7 +6,6 @@ import (
 	"github.com/atlassian-labs/cyclops/pkg/cloudprovider"
 	fakeaws "github.com/atlassian-labs/cyclops/pkg/cloudprovider/aws/fake"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -20,16 +19,14 @@ func NewCloudProvider(logger logr.Logger) (cloudprovider.CloudProvider, error) {
 		return nil, err
 	}
 
-	var creds *credentials.Credentials
-
 	// Configure AWS SDK with default retry logic
 	// The AWS SDK v1 automatically uses client.DefaultRetryer which handles:
 	// - Exponential backoff
 	// - Retries for throttling errors
 	// - Retries for transient network errors
 	// - Retries for 5xx server errors
+	// AWS SDK uses its default credential chain (env vars → shared credentials file → IAM instance profile / IRSA).
 	config := &aws.Config{
-		Credentials: creds,
 		// Use AWS SDK's default retry behavior (3 retries with exponential backoff)
 		// This is sufficient for most use cases
 		MaxRetries: aws.Int(3),
@@ -44,8 +41,9 @@ func NewCloudProvider(logger logr.Logger) (cloudprovider.CloudProvider, error) {
 		logger:             logger,
 	}
 
-	// Log the provider we used
-	credValue, err := config.Credentials.Get()
+	// Log the provider we used. Credentials are resolved by the session's
+	// default chain, so read them from the session rather than the config.
+	credValue, err := sess.Config.Credentials.Get()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/cyclenoderequest/controller.go
+++ b/pkg/controller/cyclenoderequest/controller.go
@@ -182,7 +182,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	switch {
 	case versionCheckResult.skipCheck:
-		logger.Info("API version check skipped", "severity", "warning",
+		logger.V(0).Info("API version check skipped",
 			"clientAnnotation", cnrClientAPIVersionAnnotation,
 			"controllerVersion", apiVersion)
 	case versionCheckResult.failed:

--- a/pkg/controller/cyclenoderequest/controller.go
+++ b/pkg/controller/cyclenoderequest/controller.go
@@ -117,6 +117,48 @@ func tlsCertsValid(tlsConfig v1.TLSConfig) error {
 	return nil
 }
 
+// apiVersionCheckResult holds the outcome of checkAPIVersionCompatibility.
+type apiVersionCheckResult struct {
+
+	skipCheck bool
+	// failed indicates the CNR should be marked as Failed.
+	failed bool
+	// failMsg is the human-readable reason when failed is true.
+	failMsg string
+}
+
+// Validates that the client API version in CNR annotation is compatible with the controller's build-time API version.
+func checkAPIVersionCompatibility(cnrAnnotation, controllerVersion string) (apiVersionCheckResult, error) {
+	// No annotation set by the client, skip check.
+	if cnrAnnotation == "" || cnrAnnotation == "undefined" {
+		return apiVersionCheckResult{skipCheck: true}, nil
+	}
+
+	// Controller binary was not stamped with an API version at build time, skip check.
+	if controllerVersion == "undefined" {
+		return apiVersionCheckResult{skipCheck: true}, nil
+	}
+
+	controllerAPIVersion, err := version.NewVersion(controllerVersion)
+	if err != nil {
+		return apiVersionCheckResult{}, err
+	}
+
+	clientAPIVersion, err := version.NewVersion(cnrAnnotation)
+	if err != nil {
+		return apiVersionCheckResult{}, err
+	}
+
+	if clientAPIVersion.LessThan(controllerAPIVersion) {
+		return apiVersionCheckResult{
+			failed:  true,
+			failMsg: "Client API version " + cnrAnnotation + " does not match controller API version " + controllerVersion,
+		}, nil
+	}
+
+	return apiVersionCheckResult{}, nil
+}
+
 // Reconcile reconciles the incoming request, usually a cycleNodeRequest
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	logger := log.WithValues("name", request.Name, "namespace", request.Namespace, "controller", controllerName)
@@ -134,19 +176,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	cnrClientAPIVersionAnnotation := cycleNodeRequest.Annotations[ClientAPIVersionAnnotation]
-	if cnrClientAPIVersionAnnotation != "" {
-		controllerAPIVersion, err := version.NewVersion(apiVersion)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		clientAPIVersion, err := version.NewVersion(cnrClientAPIVersionAnnotation)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		if clientAPIVersion.LessThan(controllerAPIVersion) {
-			cycleNodeRequest.Status.Phase = v1.CycleNodeRequestFailed
-			cycleNodeRequest.Status.Message = "Client API version " + cnrClientAPIVersionAnnotation + " does not match controller API version " + apiVersion
-		}
+	versionCheckResult, err := checkAPIVersionCompatibility(cnrClientAPIVersionAnnotation, apiVersion)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	switch {
+	case versionCheckResult.skipCheck:
+		logger.Info("API version check skipped", "severity", "warning",
+			"clientAnnotation", cnrClientAPIVersionAnnotation,
+			"controllerVersion", apiVersion)
+	case versionCheckResult.failed:
+		cycleNodeRequest.Status.Phase = v1.CycleNodeRequestFailed
+		cycleNodeRequest.Status.Message = versionCheckResult.failMsg
 	}
 
 	if r.notifier != nil {

--- a/pkg/controller/cyclenoderequest/controller_test.go
+++ b/pkg/controller/cyclenoderequest/controller_test.go
@@ -1,0 +1,130 @@
+package cyclenoderequest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckAPIVersionCompatibility covers every branch of checkAPIVersionCompatibility.
+func TestCheckAPIVersionCompatibility(t *testing.T) {
+	tests := []struct {
+		name                string
+		cnrAnnotation       string
+		controllerVersion   string
+		wantSkip            bool
+		wantFailed          bool
+		wantFailMsgContains string
+		wantErr             bool
+	}{
+		// No client annotation 
+		{
+			name:              "empty annotation skips check",
+			cnrAnnotation:     "",
+			controllerVersion: "1.2.0",
+			wantSkip:          true,
+			wantFailed:        false,
+		},
+		{
+			name:              "annotation value 'undefined' skips check",
+			cnrAnnotation:     "undefined",
+			controllerVersion: "1.2.0",
+			wantSkip:          true,
+			wantFailed:        false,
+		},
+
+		// Controller version not injected via ldflags
+		{
+			name:              "controller version undefined skips check and continues reconciliation",
+			cnrAnnotation:     "1.0.0",
+			controllerVersion: "undefined",
+			wantSkip:          true,
+			wantFailed:        false,
+		},
+
+		// Version comparison
+		{
+			name:              "client version equal to controller version is compatible",
+			cnrAnnotation:     "1.2.0",
+			controllerVersion: "1.2.0",
+			wantSkip:          false,
+			wantFailed:        false,
+		},
+		{
+			name:              "client version newer than controller version is compatible",
+			cnrAnnotation:     "1.3.0",
+			controllerVersion: "1.2.0",
+			wantSkip:          false,
+			wantFailed:        false,
+		},
+		{
+			name:                "client version older than controller version fails the CNR",
+			cnrAnnotation:       "1.1.0",
+			controllerVersion:   "1.2.0",
+			wantSkip:            false,
+			wantFailed:          true,
+			wantFailMsgContains: "1.1.0",
+		},
+		{
+			name:                "client version significantly older than controller version fails",
+			cnrAnnotation:       "0.9.0",
+			controllerVersion:   "2.0.0",
+			wantSkip:            false,
+			wantFailed:          true,
+			wantFailMsgContains: "0.9.0",
+		},
+		{
+			name:              "client patch version newer is compatible",
+			cnrAnnotation:     "1.2.3",
+			controllerVersion: "1.2.2",
+			wantSkip:          false,
+			wantFailed:        false,
+		},
+		{
+			name:                "client patch version older fails",
+			cnrAnnotation:       "1.2.1",
+			controllerVersion:   "1.2.2",
+			wantSkip:            false,
+			wantFailed:          true,
+			wantFailMsgContains: "1.2.1",
+		},
+
+		// Malformed versions
+		{
+			name:              "malformed controller version returns error",
+			cnrAnnotation:     "1.0.0",
+			controllerVersion: "not-a-version",
+			wantErr:           true,
+		},
+		{
+			name:              "malformed client annotation returns error",
+			cnrAnnotation:     "not-a-version",
+			controllerVersion: "1.0.0",
+			wantErr:           true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := checkAPIVersionCompatibility(tc.cnrAnnotation, tc.controllerVersion)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantSkip, result.skipCheck, "skipCheck mismatch")
+			assert.Equal(t, tc.wantFailed, result.failed, "failed mismatch")
+
+			if tc.wantFailMsgContains != "" {
+				assert.Contains(t, result.failMsg, tc.wantFailMsgContains)
+				// Ensure the controller version is also surfaced in the message
+				assert.Contains(t, result.failMsg, tc.controllerVersion)
+			} else {
+				assert.Empty(t, result.failMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Fix CNR and controller version check to skip if the versions are not set or undefined:
- E.g. When:
```
bash-5.3$ k get cnr weekly-cycle-1768810003-system -o jsonpath='{.metadata.annotations}'
{"client.api.version":"undefined","reason":"cli"}
bash-5.3$
```
  - Before:
  ```
  {"level":"error","ts":"2026-02-03T23:28:35Z","msg":"Reconciler error","controller":"cyclenoderequest.controller","object":{"name":"weekly-cycle-1768810003-system","namespace":"kube-system"},"namespace":"kube-system","name":"weekly-cycle-1768810003-system","reconcileID":"adbd95d7-be79-4c82-ab42-dd4e800fece7","error":"Malformed version: undefined","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}
```
  - Now:
  ```
{"level":"info","ts":"2026-03-19T01:23:45Z","logger":"cyclenoderequest.controller","msg":"API version check skipped","name":"observer-system-rzj60","namespace":"kube-system","controller":"cyclenoderequest.controller","severity":"warning","clientAnnotation":"undefined","controllerVersion":"1.0.0"}
{"level":"info","ts":"2026-03-19T01:23:45Z","logger":"cyclenoderequest.controller","msg":"Transitioning cycleNodeRequest","name":"observer-system-rzj60","namespace":"kube-system","phase":"WaitingTermination"}
```
  
- v1.10.3 was trying to load AWS credentials from `aws.Config` and failing, updated it to rely on the standard AWS credential chain (env vars -> ~/.aws/credentials -> IAM instance profile / IRSA).
```
│ panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                                                                                           
│ [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x185f1a3]                                                                                                                                                                                                          
│                                                                                                                                                                                                                                                                                   
│ goroutine 89 [running]:                                                                                                                                                                                                                                                           
│ github.com/aws/aws-sdk-go/aws/credentials.(*Credentials).asyncIsExpired.func1()                                                                                                                                                                                                   
│     /go/pkg/mod/github.com/aws/aws-sdk-go@v1.55.6/aws/credentials/credentials.go:330 +0x43                                                                                                                                                                                        
│ created by github.com/aws/aws-sdk-go/aws/credentials.(*Credentials).asyncIsExpired in goroutine 1                                                                                                                                                                                 
│     /go/pkg/mod/github.com/aws/aws-sdk-go@v1.55.6/aws/credentials/credentials.go:329 +0x78                                                                                                                                                                                        
│ stream closed: EOF for kube-system/cyclops-observer-549f6f8b66-vrvnj (observer)
```
