### PR TITLE
aws: tag EC2 instance with detach timestamp on DetachInstance

### DIFF
--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/atlassian-labs/cyclops/pkg/cloudprovider"
 	"github.com/aws/aws-sdk-go/aws"
@@ -290,6 +291,24 @@ func (a *autoscalingGroups) DetachInstance(providerID string) (alreadyDetaching 
 		InstanceIds:                    aws.StringSlice([]string{instanceID}),
 		ShouldDecrementDesiredCapacity: aws.Bool(false),
 	})
+
+	// Tag the instance with the detach timestamp so orphaned instances
+	// (where re-attach fails during healing) can be identified and cleaned up.
+	// Tag failure is non-fatal — logged but does not affect the detach result.
+	if apiErr == nil {
+		_, tagErr := a.ec2Service.CreateTags(&ec2.CreateTagsInput{
+			Resources: aws.StringSlice([]string{instanceID}),
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String("cyclops:detached-at"),
+					Value: aws.String(time.Now().UTC().Format(time.RFC3339)),
+				},
+			},
+		})
+		if tagErr != nil {
+			a.logger.Error(tagErr, "failed to tag detached instance", "instanceID", instanceID)
+		}
+	}
 
 	return verifyIfErrorOccurred(apiErr, alreadyDetachingMessage)
 }

--- a/pkg/cloudprovider/aws/fake/fake.go
+++ b/pkg/cloudprovider/aws/fake/fake.go
@@ -177,3 +177,7 @@ func (m *Ec2) TerminateInstances(input *ec2.TerminateInstancesInput) (*ec2.Termi
 
 	return &ec2.TerminateInstancesOutput{}, nil
 }
+
+func (m *Ec2) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	return &ec2.CreateTagsOutput{}, nil
+}


### PR DESCRIPTION
When a CycleNodeRequest fails mid-cycle and the healing path is unable to re-attach the detached instance (e.g. due to missing IAM permissions or a transient error), the instance continues running outside the ASG — invisible to the autoscaler, not terminated, and accumulating cost.

Tag the instance with `cyclops:detached-at=<RFC3339 timestamp>` immediately after a successful DetachInstances call. This makes orphaned instances trivially discoverable:

  aws ec2 describe-instances \
    --filters "Name=tag-key,Values=cyclops:detached-at"

Tag failure is non-fatal — logged but does not affect the detach result. Also add a no-op CreateTags implementation to the fake EC2 client so tests continue to pass.

  ---
  IAM permissions required

  To use this feature, add ec2:CreateTags to the cyclops-operator IAM role policy, scoped to cluster-owned instances and restricted to the cyclops:detached-at tag key only:

  {
    "Sid": "EC2TagPermission",
    "Effect": "Allow",
    "Action": "ec2:CreateTags",
    "Resource": "*",
    "Condition": {
      "StringEquals": {
        "ec2:ResourceTag/kubernetes.io/cluster/<cluster-name>": "owned"
      },
      "ForAllValues:StringEquals": {
        "aws:TagKeys": ["cyclops:detached-at"]
      }
    }
  }

  Tag failure is non-fatal — if the permission is missing, cyclops logs the error and continues normally.