### PR TITLE
further prep for integration tests

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,14 +7,11 @@ import (
 	"runtime"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/atlassian-labs/cyclops/pkg/apis"
 	"github.com/atlassian-labs/cyclops/pkg/cloudprovider/builder"
-	"github.com/atlassian-labs/cyclops/pkg/controller/cyclenoderequest"
+	cyclopsmanager "github.com/atlassian-labs/cyclops/pkg/manager"
 	cnrTransitioner "github.com/atlassian-labs/cyclops/pkg/controller/cyclenoderequest/transitioner"
-	"github.com/atlassian-labs/cyclops/pkg/controller/cyclenodestatus"
 	cnsTransitioner "github.com/atlassian-labs/cyclops/pkg/controller/cyclenodestatus/transitioner"
 	nodecontroller "github.com/atlassian-labs/cyclops/pkg/controller/node"
-	"github.com/atlassian-labs/cyclops/pkg/metrics"
 	"github.com/atlassian-labs/cyclops/pkg/notifications"
 	"github.com/atlassian-labs/cyclops/pkg/notifications/notifierbuilder"
 	"github.com/operator-framework/operator-lib/leader"
@@ -100,17 +97,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("Registering Components.")
-
-	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "Unable to setup scheme")
-		os.Exit(1)
-	}
-
-	// Register the custom metrics
-	metrics.Register(mgr.GetClient(), log, *namespace)
-
 	// Setup the cloud provider
 	// Uses AWS SDK's built-in retry behavior
 	cloudProvider, err := builder.BuildCloudProvider(*cloudProviderName, logger)
@@ -130,57 +116,37 @@ func main() {
 		}
 	}
 
-	// Configure the CNR transitioner options
-	cnrOptions := cnrTransitioner.Options{
-		DeleteCNR:                *deleteCNR,
-		DeleteCNRExpiry:          *deleteCNRExpiry,
-		DeleteCNRRequeue:         *deleteCNRRequeue,
-		HealthCheckTimeout:       *healthCheckTimeout,
-		ScaleUpWait:              *cnrScaleUpWait,
-		ScaleUpLimit:             *cnrScaleUpLimit,
-		NodeEquilibriumWaitLimit: *cnrNodeEquilibriumWaitLimit,
-		TransitionDuration:       *cnrTransitionDuration,
-		RequeueDuration:          *cnrRequeueDuration,
-	}
-
-	// Configure the CNS transitioner options
-	cnsOptions := cnsTransitioner.Options{
-		DefaultCNScyclingExpiry:          *defaultCNScyclingExpiry,
-		UnhealthyPodTerminationThreshold: *unhealthyPodTerminationThreshold,
-		TransitionDuration:               *cnsTransitionDuration,
-		WaitingPodsRequeue:               *cnsWaitingPodsRequeue,
-		RemovingLabelsPodsRequeue:        *cnsRemovingLabelsPodsRequeue,
-		DrainingRetryRequeue:             *cnsDrainingRetryRequeue,
-		DrainingPodsRequeue:              *cnsDrainingPodsRequeue,
-	}
-
-	// Configure the node controller options
-	nodeOptions := nodecontroller.Options{
-		ReconcileConcurrency: *nodeControllerReconcileConcurrency,
-		RequeueAfter:         *nodeControllerRequeueAfter,
-	}
-
-	// Set up and register the controllers that will share resources between them
-	_, err = cyclenoderequest.NewReconciler(mgr, cloudProvider, notifier, *namespace, cnrOptions)
-	if err != nil {
-		log.Error(err, "Unable to add cycleNodeRequest controller")
-		os.Exit(1)
-	}
-	_, err = cyclenodestatus.NewReconciler(mgr, cloudProvider, notifier, *namespace, cnsOptions)
-	if err != nil {
-		log.Error(err, "Unable to add cycleNodeStatus controller")
-		os.Exit(1)
-	}
-	_, err = nodecontroller.NewReconciler(mgr, *namespace, nodeOptions)
-	if err != nil {
-		log.Error(err, "Unable to add node controller")
-		os.Exit(1)
-	}
-
 	log.Info("Starting the Cmd.")
 
-	// Start the Cmd
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+	if err := cyclopsmanager.Run(signals.SetupSignalHandler(), mgr, cyclopsmanager.Dependencies{
+		CloudProvider: cloudProvider,
+		Notifier:      notifier,
+		Namespace:     *namespace,
+		CNROptions: cnrTransitioner.Options{
+			DeleteCNR:                *deleteCNR,
+			DeleteCNRExpiry:          *deleteCNRExpiry,
+			DeleteCNRRequeue:         *deleteCNRRequeue,
+			HealthCheckTimeout:       *healthCheckTimeout,
+			ScaleUpWait:              *cnrScaleUpWait,
+			ScaleUpLimit:             *cnrScaleUpLimit,
+			NodeEquilibriumWaitLimit: *cnrNodeEquilibriumWaitLimit,
+			TransitionDuration:       *cnrTransitionDuration,
+			RequeueDuration:          *cnrRequeueDuration,
+		},
+		CNSOptions: cnsTransitioner.Options{
+			DefaultCNScyclingExpiry:          *defaultCNScyclingExpiry,
+			UnhealthyPodTerminationThreshold: *unhealthyPodTerminationThreshold,
+			TransitionDuration:               *cnsTransitionDuration,
+			WaitingPodsRequeue:               *cnsWaitingPodsRequeue,
+			RemovingLabelsPodsRequeue:        *cnsRemovingLabelsPodsRequeue,
+			DrainingRetryRequeue:             *cnsDrainingRetryRequeue,
+			DrainingPodsRequeue:              *cnsDrainingPodsRequeue,
+		},
+		NodeOptions: nodecontroller.Options{
+			ReconcileConcurrency: *nodeControllerReconcileConcurrency,
+			RequeueAfter:         *nodeControllerRequeueAfter,
+		},
+	}); err != nil {
 		log.Error(err, "Manager exited non-zero")
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/operator-framework/operator-lib v0.17.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
+	github.com/prometheus/client_model v0.6.1
 	github.com/slack-go/slack v0.23.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
@@ -64,7 +65,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -84,6 +84,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.32.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -59,28 +59,24 @@ func IsCordoned(name string, client kubernetes.Interface) (bool, error) {
 
 // AddLabelToNode performs a patch operation on a node to add a label to the node
 func AddLabelToNode(nodeName string, labelName string, labelValue string, client kubernetes.Interface) error {
-	patches := []Patch{
-		{
-			Op: "add",
-			// json patch spec maps "~1" to "/" as an escape sequence, so we do the translation here...
-			Path:  fmt.Sprintf("/metadata/labels/%s", strings.ReplaceAll(labelName, "/", "~1")),
-			Value: labelValue,
+	return MergePatchNode(nodeName, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]string{labelName: labelValue},
 		},
-	}
-	return PatchNode(nodeName, patches, client)
+	}, client)
 }
 
-// AddAnnotationToNode performs a patch operation on a node to add an annotation to the node
+// AddAnnotationToNode performs a merge patch on a node to add an annotation.
+// A merge patch is used rather than a JSON Patch "add" operation because the
+// latter fails when the node's annotations map is nil (which can happen in
+// envtest and occasionally in real clusters before the kubelet has written
+// its own annotations).
 func AddAnnotationToNode(nodeName string, annotationName string, annotationValue string, client kubernetes.Interface) error {
-	patches := []Patch{
-		{
-			Op: "add",
-			// json patch spec maps "~1" to "/" as an escape sequence, so we do the translation here...
-			Path:  fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(annotationName, "/", "~1")),
-			Value: annotationValue,
+	return MergePatchNode(nodeName, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{annotationName: annotationValue},
 		},
-	}
-	return PatchNode(nodeName, patches, client)
+	}, client)
 }
 
 // RemoveAnnotationFromNode performs a patch operation on a node to remove an annotation from the node
@@ -132,17 +128,6 @@ func RemoveScaleDownDisabledAnnotationsFromNode(nodeName string, client kubernet
 		ClusterAutoscalerScaleDownDisabledAnnotation,
 		CyclopsManagedAnnotation,
 	)
-}
-
-// RemoveLabelFromNode performs a patch operation on a node to remove a label from the node
-func RemoveLabelFromNode(nodeName string, labelName string, client kubernetes.Interface) error {
-	patches := []Patch{
-		{
-			Op:   "remove",
-			Path: fmt.Sprintf("/metadata/labels/%s", strings.ReplaceAll(labelName, "/", "~1")),
-		},
-	}
-	return PatchNode(nodeName, patches, client)
 }
 
 // AddFinalizerToNode updates a node to add a finalizer to it

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -1,0 +1,136 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// newNodeForPatch creates a minimal node and registers it with a fresh fake
+// clientset, returning both. Using fake.NewSimpleClientset means patch calls
+// go through the object tracker and work out of the box.
+func newNodeForPatch(name string, annotations, labels map[string]string) (*corev1.Node, *fake.Clientset) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+	}
+	client := fake.NewSimpleClientset(node)
+	return node, client
+}
+
+// TestAddAnnotationToNode_WithExistingAnnotations verifies that
+// AddAnnotationToNode merges into an existing annotations map without
+// clobbering other entries.
+func TestAddAnnotationToNode_WithExistingAnnotations(t *testing.T) {
+	node, client := newNodeForPatch("test-node",
+		map[string]string{"existing-key": "existing-value"},
+		nil,
+	)
+
+	err := AddAnnotationToNode(node.Name, "new-key", "new-value", client)
+	require.NoError(t, err)
+
+	got, err := client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "existing-value", got.Annotations["existing-key"], "existing annotation should be preserved")
+	assert.Equal(t, "new-value", got.Annotations["new-key"], "new annotation should be set")
+}
+
+// TestAddAnnotationToNode_WithNilAnnotations verifies that AddAnnotationToNode
+// succeeds even when the node's annotations map is nil. This was the bug with
+// the old JSON Patch "add" approach: adding a key to a nil map via JSON Patch
+// fails at the apiserver level.
+func TestAddAnnotationToNode_WithNilAnnotations(t *testing.T) {
+	node, client := newNodeForPatch("test-node", nil, nil)
+
+	err := AddAnnotationToNode(node.Name, "some-key", "some-value", client)
+	require.NoError(t, err)
+
+	got, err := client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "some-value", got.Annotations["some-key"])
+}
+
+// TestAddAnnotationToNode_OverwritesExistingValue verifies that patching an
+// annotation that already exists updates its value.
+func TestAddAnnotationToNode_OverwritesExistingValue(t *testing.T) {
+	node, client := newNodeForPatch("test-node",
+		map[string]string{"my-key": "old-value"},
+		nil,
+	)
+
+	err := AddAnnotationToNode(node.Name, "my-key", "new-value", client)
+	require.NoError(t, err)
+
+	got, err := client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "new-value", got.Annotations["my-key"])
+}
+
+// TestAddLabelToNode_WithExistingLabels verifies that AddLabelToNode merges
+// into an existing labels map without clobbering other entries.
+func TestAddLabelToNode_WithExistingLabels(t *testing.T) {
+	node, client := newNodeForPatch("test-node",
+		nil,
+		map[string]string{"existing-label": "existing-value"},
+	)
+
+	err := AddLabelToNode(node.Name, "new-label", "new-value", client)
+	require.NoError(t, err)
+
+	got, err := client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "existing-value", got.Labels["existing-label"], "existing label should be preserved")
+	assert.Equal(t, "new-value", got.Labels["new-label"], "new label should be set")
+}
+
+// TestAddLabelToNode_WithNilLabels verifies that AddLabelToNode succeeds even
+// when the node has no labels. Mirrors the nil-annotations case.
+func TestAddLabelToNode_WithNilLabels(t *testing.T) {
+	node, client := newNodeForPatch("test-node", nil, nil)
+
+	err := AddLabelToNode(node.Name, "role", "worker", client)
+	require.NoError(t, err)
+
+	got, err := client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "worker", got.Labels["role"])
+}
+
+// TestAddAnnotationAndLabelToNode_Independent verifies that patching
+// annotations and labels independently doesn't interfere.
+func TestAddAnnotationAndLabelToNode_Independent(t *testing.T) {
+	node, client := newNodeForPatch("test-node", nil, nil)
+
+	require.NoError(t, AddAnnotationToNode(node.Name, "ann", "ann-val", client))
+	require.NoError(t, AddLabelToNode(node.Name, "lbl", "lbl-val", client))
+
+	got, err := client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "ann-val", got.Annotations["ann"])
+	assert.Equal(t, "lbl-val", got.Labels["lbl"])
+}
+
+// TestAddAnnotationToNode_NodeNotFound verifies that an error is returned when
+// the target node doesn't exist.
+func TestAddAnnotationToNode_NodeNotFound(t *testing.T) {
+	client := fake.NewSimpleClientset() // empty — no nodes registered
+	err := AddAnnotationToNode("does-not-exist", "k", "v", client)
+	assert.Error(t, err)
+}
+
+// TestAddLabelToNode_NodeNotFound verifies that an error is returned when the
+// target node doesn't exist.
+func TestAddLabelToNode_NodeNotFound(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	err := AddLabelToNode("does-not-exist", "k", "v", client)
+	assert.Error(t, err)
+}

--- a/pkg/k8s/patch.go
+++ b/pkg/k8s/patch.go
@@ -26,12 +26,26 @@ func PatchPod(name, namespace string, patches []Patch, client kubernetes.Interfa
 	return err
 }
 
-// PatchNode patches a node
+// PatchNode patches a node using a JSON Patch (RFC 6902).
 func PatchNode(name string, patches []Patch, client kubernetes.Interface) error {
 	data, err := json.Marshal(patches)
 	if err != nil {
 		return err
 	}
 	_, err = client.CoreV1().Nodes().Patch(context.TODO(), name, types.JSONPatchType, data, v1.PatchOptions{})
+	return err
+}
+
+// MergePatchNode patches a node using a strategic merge patch. The patch
+// argument is any JSON-serialisable value describing the fields to update.
+// Unlike JSON Patch, merge patches work correctly even when the target map
+// field (e.g. metadata.annotations) is nil on the object — the apiserver
+// creates the map automatically.
+func MergePatchNode(name string, patch interface{}, client kubernetes.Interface) error {
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	_, err = client.CoreV1().Nodes().Patch(context.TODO(), name, types.StrategicMergePatchType, data, v1.PatchOptions{})
 	return err
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,0 +1,75 @@
+// Package manager provides the Run helper that wires up all cyclops
+// controllers and starts the controller-runtime manager.
+//
+// Both cmd/manager/main.go and the integration test suite use this package
+// so the production wiring and the test wiring stay in sync.
+package manager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/atlassian-labs/cyclops/pkg/apis"
+	"github.com/atlassian-labs/cyclops/pkg/cloudprovider"
+	"github.com/atlassian-labs/cyclops/pkg/controller/cyclenoderequest"
+	cnrTransitioner "github.com/atlassian-labs/cyclops/pkg/controller/cyclenoderequest/transitioner"
+	"github.com/atlassian-labs/cyclops/pkg/controller/cyclenodestatus"
+	cnsTransitioner "github.com/atlassian-labs/cyclops/pkg/controller/cyclenodestatus/transitioner"
+	nodecontroller "github.com/atlassian-labs/cyclops/pkg/controller/node"
+	"github.com/atlassian-labs/cyclops/pkg/metrics"
+	"github.com/atlassian-labs/cyclops/pkg/notifications"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Dependencies holds the external collaborators required to run cyclops.
+// The zero value is valid for optional fields (Notifier may be nil).
+type Dependencies struct {
+	// CloudProvider is used by the CNR and CNS reconcilers to interact with
+	// the cloud provider (e.g. AWS). Required.
+	CloudProvider cloudprovider.CloudProvider
+
+	// Notifier is used to push progress notifications (e.g. Slack). Optional.
+	Notifier notifications.Notifier
+
+	// Namespace is the Kubernetes namespace where CycleNodeRequests and
+	// CycleNodeStatuses are watched.
+	Namespace string
+
+	// CNROptions configures the CycleNodeRequest transitioner.
+	CNROptions cnrTransitioner.Options
+
+	// CNSOptions configures the CycleNodeStatus transitioner.
+	CNSOptions cnsTransitioner.Options
+
+	// NodeOptions configures the node reconciler.
+	NodeOptions nodecontroller.Options
+}
+
+// Run registers the cyclops scheme, all three controllers, and metrics on
+// the given manager, then starts the manager. It blocks until ctx is
+// cancelled or the manager exits.
+//
+// This function is the single source of truth for controller wiring. Both
+// cmd/manager/main.go and the integration test suite call it so that the
+// production wiring and the test wiring stay in sync.
+func Run(ctx context.Context, mgr manager.Manager, deps Dependencies) error {
+	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		return fmt.Errorf("adding cyclops scheme: %w", err)
+	}
+
+	metrics.Register(mgr.GetClient(), ctrl.Log, deps.Namespace)
+
+	if _, err := cyclenoderequest.NewReconciler(mgr, deps.CloudProvider, deps.Notifier, deps.Namespace, deps.CNROptions); err != nil {
+		return fmt.Errorf("registering CycleNodeRequest reconciler: %w", err)
+	}
+	if _, err := cyclenodestatus.NewReconciler(mgr, deps.CloudProvider, deps.Notifier, deps.Namespace, deps.CNSOptions); err != nil {
+		return fmt.Errorf("registering CycleNodeStatus reconciler: %w", err)
+	}
+	if _, err := nodecontroller.NewReconciler(mgr, deps.Namespace, deps.NodeOptions); err != nil {
+		return fmt.Errorf("registering Node reconciler: %w", err)
+	}
+
+	return mgr.Start(ctx)
+}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,0 +1,58 @@
+package manager_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	atlassianv1 "github.com/atlassian-labs/cyclops/pkg/apis/atlassian/v1"
+	"github.com/atlassian-labs/cyclops/pkg/apis"
+	cnrTransitioner "github.com/atlassian-labs/cyclops/pkg/controller/cyclenoderequest/transitioner"
+	cnsTransitioner "github.com/atlassian-labs/cyclops/pkg/controller/cyclenodestatus/transitioner"
+	nodecontroller "github.com/atlassian-labs/cyclops/pkg/controller/node"
+	"github.com/atlassian-labs/cyclops/pkg/manager"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// TestDependencies_ZeroValuesAreDocumented verifies that the Dependencies
+// struct compiles and its fields are accessible. This is a lightweight guard
+// against field renames breaking callers that build Dependencies directly.
+func TestDependencies_ZeroValuesAreDocumented(t *testing.T) {
+	deps := manager.Dependencies{
+		Namespace:   "kube-system",
+		CNROptions:  cnrTransitioner.Options{},
+		CNSOptions:  cnsTransitioner.Options{},
+		NodeOptions: nodecontroller.Options{},
+	}
+	assert.Equal(t, "kube-system", deps.Namespace)
+	assert.Nil(t, deps.CloudProvider)
+	assert.Nil(t, deps.Notifier)
+}
+
+// TestScheme_ContainsCyclopsTypes verifies that the cyclops scheme (registered
+// by apis.AddToScheme, which Run calls internally) includes all three CRD
+// types that cyclops controllers reconcile.
+//
+// This is the meaningful unit-testable part of Run: scheme registration is
+// the first thing Run does, and if it fails Run returns an error immediately.
+// The rest of Run (reconciler wiring, mgr.Start) requires a live apiserver
+// and is covered by the integration tests.
+func TestScheme_ContainsCyclopsTypes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, apis.AddToScheme(scheme))
+
+	for _, obj := range []runtime.Object{
+		&atlassianv1.CycleNodeRequest{},
+		&atlassianv1.CycleNodeRequestList{},
+		&atlassianv1.CycleNodeStatus{},
+		&atlassianv1.CycleNodeStatusList{},
+		&atlassianv1.NodeGroup{},
+		&atlassianv1.NodeGroupList{},
+	} {
+		gvks, _, err := scheme.ObjectKinds(obj)
+		assert.NoError(t, err, "scheme should recognise %T", obj)
+		assert.NotEmpty(t, gvks, "scheme should have at least one GVK for %T", obj)
+	}
+}


### PR DESCRIPTION
# Further prep for integration tests

Follow-up to #144. Two production changes and their unit tests.

## Changes

### `pkg/k8s` — use merge patch for node annotations and labels

`AddAnnotationToNode` and `AddLabelToNode` previously used a JSON Patch
`"add"` operation. This fails at the apiserver when the node's
`metadata.annotations` / `metadata.labels` map is nil — something that
happens in envtest (no kubelet to initialise the map) and occasionally in
real clusters before a kubelet has written its own annotations.

Both functions now use a strategic merge patch via the new `MergePatchNode`
helper, which the apiserver handles correctly regardless of whether the map
exists. Behaviour in normal clusters is identical.

8 unit tests added in `pkg/k8s/node_test.go`, including an explicit
nil-annotations case that would have failed before this change.

### `pkg/manager` — extract controller wiring into `Run`

`cmd/manager/main.go` used to inline scheme registration and all three
reconciler registrations. The integration test `world` package had to
duplicate that wiring, meaning any future change to controller setup could
silently diverge between production and tests.

`pkg/manager.Run(ctx, mgr, deps)` is now the single place that registers
the cyclops scheme, metrics, and all three controllers.
`cmd/manager/main.go` and the integration test suite both call it.

2 unit tests added in `pkg/manager/manager_test.go`.